### PR TITLE
Feature/login real front

### DIFF
--- a/src/app/providers/AuthProvider.test.tsx
+++ b/src/app/providers/AuthProvider.test.tsx
@@ -1,7 +1,14 @@
+jest.mock('../../features/auth-by-credencials/model/authService.ts', () => ({
+  getAuthenticatedUser: jest.fn(),
+}));
+
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AuthProvider, useAuth } from './AuthProvider';
 import type { User } from '../../entities/user/model/types';
+import { getAuthenticatedUser } from '../../features/auth-by-credencials/model/authService.ts';
+
+const getAuthenticatedUserMock = getAuthenticatedUser as jest.Mock;
 
 const user: User = {
   id: 'user-1',
@@ -21,8 +28,9 @@ const AuthConsumer = () => {
   return (
     <div>
       <span>{auth.isAuthenticated ? 'authenticated' : 'anonymous'}</span>
+      <span>{auth.isLoading ? 'loading' : 'loaded'}</span>
       <span>{auth.user?.name ?? 'no-user'}</span>
-      <button type="button" onClick={() => auth.login('access-token', 'refresh-token', user)}>
+      <button type="button" onClick={() => void auth.login('access-token', 'refresh-token')}>
         login
       </button>
       <button type="button" onClick={auth.logout}>
@@ -35,11 +43,13 @@ const AuthConsumer = () => {
 describe('AuthProvider', () => {
   afterEach(() => {
     localStorage.clear();
+    getAuthenticatedUserMock.mockReset();
     jest.restoreAllMocks();
   });
 
   it('stores tokens and exposes the authenticated user on login', async () => {
     const testUser = userEvent.setup();
+    getAuthenticatedUserMock.mockResolvedValueOnce(user);
 
     render(
       <AuthProvider>
@@ -51,14 +61,16 @@ describe('AuthProvider', () => {
 
     await testUser.click(screen.getByRole('button', { name: 'login' }));
 
-    expect(screen.getByText('authenticated')).toBeInTheDocument();
+    expect(await screen.findByText('authenticated')).toBeInTheDocument();
     expect(screen.getByText('Ana Estudante')).toBeInTheDocument();
+    expect(getAuthenticatedUserMock).toHaveBeenCalledTimes(1);
     expect(localStorage.getItem('access_token')).toBe('access-token');
     expect(localStorage.getItem('refresh_token')).toBe('refresh-token');
   });
 
   it('clears tokens and user state on logout', async () => {
     const testUser = userEvent.setup();
+    getAuthenticatedUserMock.mockResolvedValueOnce(user);
 
     render(
       <AuthProvider>
@@ -67,10 +79,44 @@ describe('AuthProvider', () => {
     );
 
     await testUser.click(screen.getByRole('button', { name: 'login' }));
+    expect(await screen.findByText('authenticated')).toBeInTheDocument();
     await testUser.click(screen.getByRole('button', { name: 'logout' }));
 
     expect(screen.getByText('anonymous')).toBeInTheDocument();
     expect(screen.getByText('no-user')).toBeInTheDocument();
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+
+  it('restores the authenticated user when there is a stored token', async () => {
+    localStorage.setItem('access_token', 'stored-access-token');
+    getAuthenticatedUserMock.mockResolvedValueOnce(user);
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText('loading')).toBeInTheDocument();
+    expect(await screen.findByText('authenticated')).toBeInTheDocument();
+    expect(screen.getByText('loaded')).toBeInTheDocument();
+    expect(screen.getByText('Ana Estudante')).toBeInTheDocument();
+  });
+
+  it('clears stored tokens when session restoration fails', async () => {
+    localStorage.setItem('access_token', 'invalid-access-token');
+    localStorage.setItem('refresh_token', 'invalid-refresh-token');
+    getAuthenticatedUserMock.mockRejectedValueOnce(new Error('Sessao expirada'));
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    expect(await screen.findByText('loaded')).toBeInTheDocument();
+    expect(screen.getByText('anonymous')).toBeInTheDocument();
     expect(localStorage.getItem('access_token')).toBeNull();
     expect(localStorage.getItem('refresh_token')).toBeNull();
   });

--- a/src/app/providers/AuthProvider.test.tsx
+++ b/src/app/providers/AuthProvider.test.tsx
@@ -30,7 +30,10 @@ const AuthConsumer = () => {
       <span>{auth.isAuthenticated ? 'authenticated' : 'anonymous'}</span>
       <span>{auth.isLoading ? 'loading' : 'loaded'}</span>
       <span>{auth.user?.name ?? 'no-user'}</span>
-      <button type="button" onClick={() => void auth.login('access-token', 'refresh-token')}>
+      <button
+        type="button"
+        onClick={() => void auth.login('access-token', 'refresh-token').catch(() => undefined)}
+      >
         login
       </button>
       <button type="button" onClick={auth.logout}>
@@ -66,6 +69,36 @@ describe('AuthProvider', () => {
     expect(getAuthenticatedUserMock).toHaveBeenCalledTimes(1);
     expect(localStorage.getItem('access_token')).toBe('access-token');
     expect(localStorage.getItem('refresh_token')).toBe('refresh-token');
+  });
+
+  it('starts loaded when there is no stored token', () => {
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText('loaded')).toBeInTheDocument();
+    expect(screen.getByText('anonymous')).toBeInTheDocument();
+    expect(getAuthenticatedUserMock).not.toHaveBeenCalled();
+  });
+
+  it('clears tokens and keeps login rejected when authenticated user load fails after login', async () => {
+    const testUser = userEvent.setup();
+    getAuthenticatedUserMock.mockRejectedValueOnce(new Error('Sessao invalida'));
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await testUser.click(screen.getByRole('button', { name: 'login' }));
+
+    expect(await screen.findByText('anonymous')).toBeInTheDocument();
+    expect(screen.getByText('no-user')).toBeInTheDocument();
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
   });
 
   it('clears tokens and user state on logout', async () => {

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -1,18 +1,14 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
+import { getAuthenticatedUser } from '../../features/auth-by-credencials/model/authService.ts';
 import type { User, AuthState } from '../../entities/user/model/types.ts';
 
 const AuthContext = createContext<AuthState | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const [user, setUser] = useState<User | null>(null);
-
-    const login = useCallback((accessToken: string, refreshToken: string, userData: User) => {
-        localStorage.setItem('access_token', accessToken);
-        localStorage.setItem('refresh_token', refreshToken);
-        setUser(userData);
-    }, []);
+    const [isLoading, setIsLoading] = useState(true);
 
     const logout = useCallback(() => {
         localStorage.removeItem('access_token');
@@ -20,9 +16,60 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setUser(null);
     }, []);
 
+    const loadAuthenticatedUser = useCallback(async () => {
+        const userData = await getAuthenticatedUser();
+        setUser(userData);
+    }, []);
+
+    useEffect(() => {
+        const accessToken = localStorage.getItem('access_token');
+
+        if (!accessToken) {
+            setIsLoading(false);
+            return;
+        }
+
+        let isMounted = true;
+
+        const restoreSession = async () => {
+            try {
+                const userData = await getAuthenticatedUser();
+
+                if (isMounted) {
+                    setUser(userData);
+                }
+            } catch {
+                if (isMounted) {
+                    logout();
+                }
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        void restoreSession();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [logout]);
+
+    const login = useCallback(async (accessToken: string, refreshToken: string) => {
+        localStorage.setItem('access_token', accessToken);
+        localStorage.setItem('refresh_token', refreshToken);
+        try {
+            await loadAuthenticatedUser();
+        } catch (error) {
+            logout();
+            throw error;
+        }
+    }, [loadAuthenticatedUser, logout]);
+
     const value = useMemo<AuthState>(
-        () => ({ user, isAuthenticated: !!user, login, logout }),
-        [user, login, logout],
+        () => ({ user, isAuthenticated: !!user, isLoading, login, logout }),
+        [user, isLoading, login, logout],
     );
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -8,7 +8,7 @@ const AuthContext = createContext<AuthState | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const [user, setUser] = useState<User | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
+    const [isLoading, setIsLoading] = useState(() => Boolean(localStorage.getItem('access_token')));
 
     const logout = useCallback(() => {
         localStorage.removeItem('access_token');
@@ -25,7 +25,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         const accessToken = localStorage.getItem('access_token');
 
         if (!accessToken) {
-            setIsLoading(false);
             return;
         }
 

--- a/src/app/router/ProtectedRoute.test.tsx
+++ b/src/app/router/ProtectedRoute.test.tsx
@@ -27,7 +27,7 @@ describe('App/Router/ProtectedRoute', () => {
   };
 
   it('deve redirecionar para /login se o usuário NÃO estiver autenticado', () => {
-    (useAuth as jest.Mock).mockReturnValue({ isAuthenticated: false, user: null });
+    (useAuth as jest.Mock).mockReturnValue({ isAuthenticated: false, isLoading: false, user: null });
 
     renderWithRouter(
       <ProtectedRoute>
@@ -39,9 +39,23 @@ describe('App/Router/ProtectedRoute', () => {
     expect(screen.getByTestId('login-page')).toBeInTheDocument();
   });
 
+  it('nao deve redirecionar enquanto a autenticacao estiver carregando', () => {
+    (useAuth as jest.Mock).mockReturnValue({ isAuthenticated: false, isLoading: true, user: null });
+
+    renderWithRouter(
+      <ProtectedRoute>
+        <div data-testid="conteudo-secreto">Conteúdo Secreto</div>
+      </ProtectedRoute>
+    );
+
+    expect(screen.queryByTestId('conteudo-secreto')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('login-page')).not.toBeInTheDocument();
+  });
+
   it('deve renderizar o conteúdo se o usuário estiver autenticado e não tiver restrição de Role', () => {
     (useAuth as jest.Mock).mockReturnValue({
       isAuthenticated: true,
+      isLoading: false,
       user: { role: 'STUDENT' },
     });
 
@@ -57,6 +71,7 @@ describe('App/Router/ProtectedRoute', () => {
   it('deve redirecionar para /home se o usuário estiver logado, mas não tiver a Role necessária', () => {
     (useAuth as jest.Mock).mockReturnValue({
       isAuthenticated: true,
+      isLoading: false,
       user: { role: 'STUDENT' },
     });
 
@@ -73,6 +88,7 @@ describe('App/Router/ProtectedRoute', () => {
   it('deve renderizar o conteúdo se o usuário logado tiver a Role necessária', () => {
     (useAuth as jest.Mock).mockReturnValue({
       isAuthenticated: true,
+      isLoading: false,
       user: { role: 'PROFESSOR' },
     });
 

--- a/src/app/router/ProtectedRoute.tsx
+++ b/src/app/router/ProtectedRoute.tsx
@@ -8,7 +8,12 @@ interface ProtectedRouteProps {
 }
 
 export const ProtectedRoute = ({children, allowedRoles}: ProtectedRouteProps) => {
-    const { isAuthenticated, user } = useAuth();
+    const { isAuthenticated, isLoading, user } = useAuth();
+
+    if (isLoading) {
+        return null;
+    }
+
     if(!isAuthenticated){
         return <Navigate to='/login' replace/>;
     }

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -18,6 +18,7 @@ export interface User {
 export interface AuthState {
   user: User | null;
   isAuthenticated: boolean;
-  login: (accessToken: string, refreshToken: string, user: User) => void;
+  isLoading: boolean;
+  login: (accessToken: string, refreshToken: string) => Promise<void>;
   logout: () => void;
 }

--- a/src/features/auth-by-credencials/model/authService.test.ts
+++ b/src/features/auth-by-credencials/model/authService.test.ts
@@ -142,6 +142,25 @@ describe('loginWithCredencials', () => {
     );
   });
 
+  it('throws the backend message when login is blocked by user status', async () => {
+    const { loginWithCredencials } = await loadService(false);
+    postMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 403,
+        data: {
+          erro: {
+            mensagem: 'Conta desativada. Entre em contato com o administrador.',
+          },
+        },
+      },
+    });
+
+    await expect(loginWithCredencials('professor@unb.br', 'secret')).rejects.toThrow(
+      'Conta desativada. Entre em contato com o administrador.',
+    );
+  });
+
   it('throws a generic message for unexpected errors', async () => {
     const { loginWithCredencials } = await loadService(false);
     postMock.mockRejectedValueOnce({

--- a/src/features/auth-by-credencials/model/authService.test.ts
+++ b/src/features/auth-by-credencials/model/authService.test.ts
@@ -1,12 +1,15 @@
 const postMock = jest.fn();
+const getMock = jest.fn();
 
 const loadService = async (useMocks: boolean) => {
   jest.resetModules();
   postMock.mockReset();
+  getMock.mockReset();
 
   jest.doMock('../../../shared/api/httpClient', () => ({
     httpClient: {
       post: postMock,
+      get: getMock,
     },
   }));
 
@@ -31,12 +34,6 @@ describe('loginWithCredencials', () => {
     expect(result).toMatchObject({
       accessToken: 'mock-access-token',
       refreshToken: 'mock-refresh-token',
-      user: {
-        email: 'aluno@unb.br',
-        role: 'STUDENT',
-        status: 'ACTIVE',
-        authProvider: 'LOCAL',
-      },
     });
   });
 
@@ -49,17 +46,13 @@ describe('loginWithCredencials', () => {
     expect(postMock).not.toHaveBeenCalled();
   });
 
-  it('maps a successful backend login response to the auth user shape when mocks are disabled', async () => {
+  it('returns tokens from backend login response when mocks are disabled', async () => {
     const { loginWithCredencials } = await loadService(false);
     postMock.mockResolvedValueOnce({
       data: {
-        accessToken: 'api-access',
-        refreshToken: 'api-refresh',
-        user: {
-          id: 'user-1',
-          name: 'Professor UnB',
-          email: 'professor@unb.br',
-          role: 'PROFESSOR',
+        dados: {
+          accessToken: 'api-access',
+          refreshToken: 'api-refresh',
         },
       },
     });
@@ -68,19 +61,60 @@ describe('loginWithCredencials', () => {
 
     expect(postMock).toHaveBeenCalledWith('/auth/login', {
       email: 'professor@unb.br',
-      password: 'secret',
+      senha: 'secret',
     });
     expect(result).toEqual({
       accessToken: 'api-access',
       refreshToken: 'api-refresh',
-      user: {
-        id: 'user-1',
-        name: 'Professor UnB',
-        email: 'professor@unb.br',
-        role: 'PROFESSOR',
-        status: 'ACTIVE',
-        authProvider: 'LOCAL',
+    });
+  });
+
+  it('returns the mock authenticated user without calling the API when mocks are enabled', async () => {
+    const { getAuthenticatedUser } = await loadService(true);
+
+    const result = await getAuthenticatedUser();
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      email: 'aluno@unb.br',
+      role: 'STUDENT',
+      status: 'ACTIVE',
+      authProvider: 'LOCAL',
+    });
+  });
+
+  it('maps the authenticated backend user to the auth user shape when mocks are disabled', async () => {
+    const { getAuthenticatedUser } = await loadService(false);
+    getMock.mockResolvedValueOnce({
+      data: {
+        dados: {
+          usuario: {
+            id: 'user-1',
+            nome: 'Professor UnB',
+            email: 'professor@unb.br',
+            papel: 'PROFESSOR',
+            status: 'ATIVO',
+            instituicao: 'Universidade de Brasilia',
+            curso: 'Medicina',
+            periodo: '3',
+          },
+        },
       },
+    });
+
+    const result = await getAuthenticatedUser();
+
+    expect(getMock).toHaveBeenCalledWith('/auth/me');
+    expect(result).toEqual({
+      id: 'user-1',
+      name: 'Professor UnB',
+      email: 'professor@unb.br',
+      role: 'PROFESSOR',
+      status: 'ACTIVE',
+      authProvider: 'LOCAL',
+      institution: 'Universidade de Brasilia',
+      course: 'Medicina',
+      period: 3,
     });
   });
 

--- a/src/features/auth-by-credencials/model/authService.test.ts
+++ b/src/features/auth-by-credencials/model/authService.test.ts
@@ -118,6 +118,68 @@ describe('loginWithCredencials', () => {
     });
   });
 
+  it.each([
+    ['ALUNO', 'STUDENT'],
+    ['ADMIN', 'ADMIN'],
+    ['ADMINISTRADOR', 'ADMIN'],
+  ])('maps backend role %s to frontend role %s', async (papel, role) => {
+    const { getAuthenticatedUser } = await loadService(false);
+    getMock.mockResolvedValueOnce({
+      data: {
+        dados: {
+          usuario: {
+            id: 'user-1',
+            nome: 'Usuario Teste',
+            email: 'usuario@unb.br',
+            papel,
+            status: 'ATIVO',
+            instituicao: null,
+            curso: null,
+            periodo: null,
+          },
+        },
+      },
+    });
+
+    const result = await getAuthenticatedUser();
+
+    expect(result).toMatchObject({
+      role,
+      status: 'ACTIVE',
+      institution: null,
+      course: null,
+      period: null,
+    });
+  });
+
+  it('maps blocked backend status and invalid period to inactive user with null period', async () => {
+    const { getAuthenticatedUser } = await loadService(false);
+    getMock.mockResolvedValueOnce({
+      data: {
+        dados: {
+          usuario: {
+            id: 'user-1',
+            nome: 'Aluno Pendente',
+            email: 'aluno@unb.br',
+            papel: 'ALUNO',
+            status: 'PENDENTE',
+            periodo: 'periodo-invalido',
+          },
+        },
+      },
+    });
+
+    const result = await getAuthenticatedUser();
+
+    expect(result).toMatchObject({
+      role: 'STUDENT',
+      status: 'INACTIVE',
+      institution: null,
+      course: null,
+      period: null,
+    });
+  });
+
   it('throws a friendly message when the backend is unreachable', async () => {
     const { loginWithCredencials } = await loadService(false);
     postMock.mockRejectedValueOnce({ isAxiosError: true });
@@ -173,6 +235,67 @@ describe('loginWithCredencials', () => {
 
     await expect(loginWithCredencials('professor@unb.br', 'secret')).rejects.toThrow(
       'Erro ao entrar. Tente novamente.',
+    );
+  });
+
+  it('throws a generic message for non axios login errors', async () => {
+    const { loginWithCredencials } = await loadService(false);
+    postMock.mockRejectedValueOnce(new Error('erro inesperado'));
+
+    await expect(loginWithCredencials('professor@unb.br', 'secret')).rejects.toThrow(
+      'Erro ao entrar. Tente novamente.',
+    );
+  });
+
+  it('throws a friendly message when authenticated user endpoint is unreachable', async () => {
+    const { getAuthenticatedUser } = await loadService(false);
+    getMock.mockRejectedValueOnce({ isAxiosError: true });
+
+    await expect(getAuthenticatedUser()).rejects.toThrow(
+      'Nao foi possivel conectar ao servidor. Tente novamente.',
+    );
+  });
+
+  it('throws the backend message when authenticated session is invalid', async () => {
+    const { getAuthenticatedUser } = await loadService(false);
+    getMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 401,
+        data: { erro: { mensagem: 'Sessao expirada' } },
+      },
+    });
+
+    await expect(getAuthenticatedUser()).rejects.toThrow('Sessao expirada');
+  });
+
+  it('throws a fallback session message when authenticated session has no backend message', async () => {
+    const { getAuthenticatedUser } = await loadService(false);
+    getMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 403,
+        data: {},
+      },
+    });
+
+    await expect(getAuthenticatedUser()).rejects.toThrow(
+      'Sessao expirada. Faca login novamente.',
+    );
+  });
+
+  it('throws a generic message for unexpected authenticated user errors', async () => {
+    const { getAuthenticatedUser } = await loadService(false);
+    getMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 500,
+        data: {},
+      },
+    });
+
+    await expect(getAuthenticatedUser()).rejects.toThrow(
+      'Nao foi possivel carregar o usuario autenticado.',
     );
   });
 });

--- a/src/features/auth-by-credencials/model/authService.ts
+++ b/src/features/auth-by-credencials/model/authService.ts
@@ -2,24 +2,80 @@ import axios from 'axios';
 import type { User } from '../../../entities/user/model/types';
 import { httpClient } from '../../../shared/api/httpClient';
 import { USE_MOCKS } from '../../../shared/config/env';
-import { loginWithMockCredencials } from './mockAuthService';
+import { getAuthenticatedUserMock, loginWithMockCredencials } from './mockAuthService';
 
 export interface LoginResponse {
   accessToken: string;
   refreshToken: string;
-  user: User;
 }
 
 interface BackendLoginResponse {
-  accessToken: string;
-  refreshToken: string;
-  user: {
-    id: string;
-    name: string;
-    email: string;
-    role: User['role'];
+  dados: {
+    accessToken: string;
+    refreshToken: string;
   };
 }
+
+type BackendPapel = 'ALUNO' | 'PROFESSOR' | 'ADMIN' | 'ADMINISTRADOR';
+type BackendStatus = 'ATIVO' | 'INATIVO' | 'PENDENTE' | 'RECUSADO';
+
+interface BackendUsuarioAutenticado {
+  id: string;
+  nome: string;
+  email: string;
+  papel: BackendPapel;
+  status: BackendStatus;
+  instituicao?: string | null;
+  curso?: string | null;
+  periodo?: string | null;
+}
+
+interface BackendMeResponse {
+  dados: {
+    usuario: BackendUsuarioAutenticado;
+  };
+}
+
+const mapPapelToRole = (papel: BackendPapel): User['role'] => {
+  if (papel === 'ALUNO') return 'STUDENT';
+  if (papel === 'PROFESSOR') return 'PROFESSOR';
+  return 'ADMIN';
+};
+
+const mapStatusToUserStatus = (status: BackendStatus): User['status'] => (
+  status === 'ATIVO' ? 'ACTIVE' : 'INACTIVE'
+);
+
+const mapPeriodo = (periodo?: string | null): number | null => {
+  if (!periodo) return null;
+
+  const parsedPeriodo = Number(periodo);
+  return Number.isNaN(parsedPeriodo) ? null : parsedPeriodo;
+};
+
+const mapUsuarioAutenticado = (usuario: BackendUsuarioAutenticado): User => ({
+  id: usuario.id,
+  name: usuario.nome,
+  email: usuario.email,
+  role: mapPapelToRole(usuario.papel),
+  status: mapStatusToUserStatus(usuario.status),
+  authProvider: 'LOCAL',
+  institution: usuario.instituicao ?? null,
+  course: usuario.curso ?? null,
+  period: mapPeriodo(usuario.periodo),
+});
+
+const extractErrorMessage = (err: unknown): string | null => {
+  if (!axios.isAxiosError(err) || !err.response) return null;
+
+  const responseData = err.response.data as {
+    message?: string;
+    mensagem?: string;
+    erro?: { mensagem?: string };
+  };
+
+  return responseData.erro?.mensagem ?? responseData.mensagem ?? responseData.message ?? null;
+};
 
 export const loginWithCredencials = async (
   email: string,
@@ -32,17 +88,12 @@ export const loginWithCredencials = async (
   try {
     const { data } = await httpClient.post<BackendLoginResponse>('/auth/login', {
       email,
-      password,
+      senha: password,
     });
 
     return {
-      accessToken: data.accessToken,
-      refreshToken: data.refreshToken,
-      user: {
-        ...data.user,
-        status: 'ACTIVE',
-        authProvider: 'LOCAL',
-      },
+      accessToken: data.dados.accessToken,
+      refreshToken: data.dados.refreshToken,
     };
   } catch (err) {
     if (axios.isAxiosError(err)) {
@@ -50,12 +101,7 @@ export const loginWithCredencials = async (
         throw new Error('Nao foi possivel conectar ao servidor. Tente novamente.');
       }
 
-      const responseData = err.response.data as {
-        message?: string;
-        mensagem?: string;
-        erro?: { mensagem?: string };
-      };
-      const message = responseData.erro?.mensagem ?? responseData.mensagem ?? responseData.message;
+      const message = extractErrorMessage(err);
 
       if (err.response.status === 401) {
         throw new Error(message ?? 'Email ou senha invalidos');
@@ -67,5 +113,31 @@ export const loginWithCredencials = async (
     }
 
     throw new Error('Erro ao entrar. Tente novamente.');
+  }
+};
+
+export const getAuthenticatedUser = async (): Promise<User> => {
+  if (USE_MOCKS) {
+    return getAuthenticatedUserMock();
+  }
+
+  try {
+    const { data } = await httpClient.get<BackendMeResponse>('/auth/me');
+
+    return mapUsuarioAutenticado(data.dados.usuario);
+  } catch (err) {
+    if (axios.isAxiosError(err)) {
+      if (!err.response) {
+        throw new Error('Nao foi possivel conectar ao servidor. Tente novamente.');
+      }
+
+      const message = extractErrorMessage(err);
+
+      if (err.response.status === 401 || err.response.status === 403) {
+        throw new Error(message ?? 'Sessao expirada. Faca login novamente.');
+      }
+    }
+
+    throw new Error('Nao foi possivel carregar o usuario autenticado.');
   }
 };

--- a/src/features/auth-by-credencials/model/mockAuthService.ts
+++ b/src/features/auth-by-credencials/model/mockAuthService.ts
@@ -32,9 +32,10 @@ export const loginWithMockCredencials = async (
     return {
       accessToken: 'mock-access-token',
       refreshToken: 'mock-refresh-token',
-      user: MOCK_USER,
     };
   }
 
   throw new Error('Email ou senha invalidos');
 };
+
+export const getAuthenticatedUserMock = async (): Promise<User> => MOCK_USER;

--- a/src/features/auth-by-credencials/ui/LoginForm.test.tsx
+++ b/src/features/auth-by-credencials/ui/LoginForm.test.tsx
@@ -14,21 +14,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { useAuth } from '../../../app/providers/AuthProvider';
-import type { User } from '../../../entities/user/model/types';
 import { loginWithCredencials } from '../model/authService';
 import { LoginForm } from './LoginForm';
 
 const useAuthMock = useAuth as jest.Mock;
 const loginWithCredencialsMock = loginWithCredencials as jest.Mock;
-
-const user: User = {
-  id: 'user-1',
-  name: 'Ana Estudante',
-  email: 'ana@unb.br',
-  role: 'STUDENT',
-  status: 'ACTIVE',
-  authProvider: 'LOCAL',
-};
 
 const LocationProbe = () => {
   const location = useLocation();
@@ -36,7 +26,7 @@ const LocationProbe = () => {
 };
 
 const renderLoginForm = () => {
-  const login = jest.fn();
+  const login = jest.fn().mockResolvedValue(undefined);
   useAuthMock.mockReturnValue({ login });
 
   const view = render(
@@ -72,7 +62,6 @@ describe('LoginForm', () => {
     loginWithCredencialsMock.mockResolvedValueOnce({
       accessToken: 'access-token',
       refreshToken: 'refresh-token',
-      user,
     });
 
     const { login, passwordInput } = renderLoginForm();
@@ -82,7 +71,7 @@ describe('LoginForm', () => {
     await testUser.click(screen.getByRole('button', { name: /Continuar/i }));
 
     expect(loginWithCredencialsMock).toHaveBeenCalledWith('ana@unb.br', 'secret');
-    expect(login).toHaveBeenCalledWith('access-token', 'refresh-token', user);
+    expect(login).toHaveBeenCalledWith('access-token', 'refresh-token');
     expect(screen.getByTestId('location')).toHaveTextContent('/home');
   });
 

--- a/src/features/auth-by-credencials/ui/LoginForm.tsx
+++ b/src/features/auth-by-credencials/ui/LoginForm.tsx
@@ -22,7 +22,7 @@ export const LoginForm = () => {
 
     try {
       const response = await loginWithCredencials(email, password);
-      login(response.accessToken, response.refreshToken, response.user);
+      await login(response.accessToken, response.refreshToken);
       navigate('/home');
     } catch (err) {
       const error = err as Error;


### PR DESCRIPTION
## Descrição
Implementa a integração do login real no frontend, usando o fluxo `login -> tokens -> /auth/me` para carregar o usuário autenticado e restaurar sessão ao recarregar a página.

## Rastreabilidade

Issue(s) Relacionada(s):

Closes:
Relates to:
- [US02] [Backend] Login de aluno — API

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [x] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Evidências (se aplicável)

- Login com usuário real cadastrado
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/d8a40260-76fd-413a-bb9d-689965e8ed90" />

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

O login agora salva apenas `accessToken` e `refreshToken` no `localStorage`. Após autenticar, o frontend chama `/auth/me` para buscar os dados atuais do usuário autenticado.

O `AuthProvider` também tenta restaurar a sessão ao recarregar a página quando existe `accessToken` salvo. Enquanto essa validação ocorre, as rotas protegidas aguardam o carregamento para evitar redirecionamento indevido para `/login`.