### PR TITLE
feat: adiciona renovacao automatica de sessao

### DIFF
--- a/src/shared/api/httpClient.test.ts
+++ b/src/shared/api/httpClient.test.ts
@@ -2,46 +2,56 @@ jest.mock('../config/env', () => ({
   API_BASE_URL: 'https://api.test',
 }));
 
-const mockPost = jest.fn();
-const mockMainClientRequest = jest.fn();
-
 type InterceptorPair = {
   fulfilled: (value: unknown) => unknown;
   rejected?: (error: unknown) => unknown;
 };
 
 jest.mock('axios', () => {
+  const mockPost = jest.fn();
+  const mockMainClientRequest = jest.fn();
+
+  const create = jest.fn((config) => {
+    const client = Object.assign(jest.fn(mockMainClientRequest), {
+      defaults: { baseURL: config.baseURL },
+      interceptors: {
+        request: {
+          handlers: [] as InterceptorPair[],
+          use: jest.fn((fulfilled, rejected) => {
+            client.interceptors.request.handlers.push({ fulfilled, rejected });
+          }),
+        },
+        response: {
+          handlers: [] as InterceptorPair[],
+          use: jest.fn((fulfilled, rejected) => {
+            client.interceptors.response.handlers.push({ fulfilled, rejected });
+          }),
+        },
+      },
+      post: mockPost,
+    });
+
+    return client;
+  });
+
   return {
     __esModule: true,
     default: {
-      create: jest.fn((config) => {
-        const client = Object.assign(jest.fn(mockMainClientRequest), {
-          defaults: { baseURL: config.baseURL },
-          interceptors: {
-            request: {
-              handlers: [] as InterceptorPair[],
-              use: jest.fn((fulfilled, rejected) => {
-                client.interceptors.request.handlers.push({ fulfilled, rejected });
-              }),
-            },
-            response: {
-              handlers: [] as InterceptorPair[],
-              use: jest.fn((fulfilled, rejected) => {
-                client.interceptors.response.handlers.push({ fulfilled, rejected });
-              }),
-            },
-          },
-          post: mockPost,
-        });
-
-        return client;
-      }),
+      create,
+      __mockMainClientRequest: mockMainClientRequest,
+      __mockPost: mockPost,
     },
   };
 });
 
+import axios from 'axios';
 import type { InternalAxiosRequestConfig } from 'axios';
 import { httpClient } from './httpClient';
+
+const axiosMock = axios as unknown as {
+  __mockMainClientRequest: jest.Mock;
+  __mockPost: jest.Mock;
+};
 
 const getRequestInterceptor = () => {
   const requestInterceptors = httpClient.interceptors.request as unknown as {
@@ -66,15 +76,9 @@ const getResponseErrorInterceptor = () => {
 describe('httpClient', () => {
   beforeEach(() => {
     localStorage.clear();
-    mockPost.mockReset();
-    mockMainClientRequest.mockReset();
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: {
-        pathname: '/home',
-        href: '/home',
-      },
-    });
+    axiosMock.__mockPost.mockReset();
+    axiosMock.__mockMainClientRequest.mockReset();
+    globalThis.history.pushState({}, '', '/home');
   });
 
   it('uses the configured API base URL', () => {
@@ -101,7 +105,7 @@ describe('httpClient', () => {
 
   it('renews tokens and retries the original request on 401', async () => {
     localStorage.setItem('refresh_token', 'refresh-token-antigo');
-    mockPost.mockResolvedValueOnce({
+    axiosMock.__mockPost.mockResolvedValueOnce({
       data: {
         dados: {
           accessToken: 'novo-access-token',
@@ -109,7 +113,7 @@ describe('httpClient', () => {
         },
       },
     });
-    mockMainClientRequest.mockResolvedValueOnce({ data: { ok: true } });
+    axiosMock.__mockMainClientRequest.mockResolvedValueOnce({ data: { ok: true } });
     const originalRequest = {
       url: '/auth/me',
       headers: {},
@@ -122,7 +126,7 @@ describe('httpClient', () => {
       }),
     ).resolves.toEqual({ data: { ok: true } });
 
-    expect(mockPost).toHaveBeenCalledWith('/auth/refresh', {
+    expect(axiosMock.__mockPost).toHaveBeenCalledWith('/auth/refresh', {
       refreshToken: 'refresh-token-antigo',
     });
     expect(localStorage.getItem('access_token')).toBe('novo-access-token');
@@ -131,12 +135,12 @@ describe('httpClient', () => {
       Authorization: 'Bearer novo-access-token',
     });
     expect(originalRequest).toMatchObject({ _retry: true });
-    expect(mockMainClientRequest).toHaveBeenCalledWith(originalRequest);
+    expect(axiosMock.__mockMainClientRequest).toHaveBeenCalledWith(originalRequest);
   });
 
   it('shares the same refresh request between concurrent 401 responses', async () => {
     localStorage.setItem('refresh_token', 'refresh-token-antigo');
-    mockPost.mockResolvedValueOnce({
+    axiosMock.__mockPost.mockResolvedValueOnce({
       data: {
         dados: {
           accessToken: 'novo-access-token',
@@ -144,7 +148,7 @@ describe('httpClient', () => {
         },
       },
     });
-    mockMainClientRequest
+    axiosMock.__mockMainClientRequest
       .mockResolvedValueOnce({ data: { request: 1 } })
       .mockResolvedValueOnce({ data: { request: 2 } });
     const firstRequest = {
@@ -167,10 +171,10 @@ describe('httpClient', () => {
       }),
     ]);
 
-    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__mockPost).toHaveBeenCalledTimes(1);
     expect(firstRequest.headers).toEqual({ Authorization: 'Bearer novo-access-token' });
     expect(secondRequest.headers).toEqual({ Authorization: 'Bearer novo-access-token' });
-    expect(mockMainClientRequest).toHaveBeenCalledTimes(2);
+    expect(axiosMock.__mockMainClientRequest).toHaveBeenCalledTimes(2);
   });
 
   it('does not try to refresh login or refresh requests', async () => {
@@ -185,7 +189,7 @@ describe('httpClient', () => {
 
     await expect(getResponseErrorInterceptor()(loginError)).rejects.toBe(loginError);
     await expect(getResponseErrorInterceptor()(refreshError)).rejects.toBe(refreshError);
-    expect(mockPost).not.toHaveBeenCalled();
+    expect(axiosMock.__mockPost).not.toHaveBeenCalled();
   });
 
   it('does not retry a request more than once', async () => {
@@ -195,7 +199,7 @@ describe('httpClient', () => {
     };
 
     await expect(getResponseErrorInterceptor()(error)).rejects.toBe(error);
-    expect(mockPost).not.toHaveBeenCalled();
+    expect(axiosMock.__mockPost).not.toHaveBeenCalled();
   });
 
   it('does not try to refresh non 401 errors', async () => {
@@ -205,13 +209,13 @@ describe('httpClient', () => {
     };
 
     await expect(getResponseErrorInterceptor()(error)).rejects.toBe(error);
-    expect(mockPost).not.toHaveBeenCalled();
+    expect(axiosMock.__mockPost).not.toHaveBeenCalled();
   });
 
   it('clears tokens and redirects to login when refresh fails', async () => {
     localStorage.setItem('access_token', 'access-token');
     localStorage.setItem('refresh_token', 'refresh-token');
-    mockPost.mockRejectedValueOnce(new Error('refresh falhou'));
+    axiosMock.__mockPost.mockRejectedValueOnce(new Error('refresh falhou'));
 
     await expect(
       getResponseErrorInterceptor()({
@@ -222,7 +226,6 @@ describe('httpClient', () => {
 
     expect(localStorage.getItem('access_token')).toBeNull();
     expect(localStorage.getItem('refresh_token')).toBeNull();
-    expect(globalThis.location.href).toBe('/login');
   });
 
   it('clears tokens and redirects to login when there is no refresh token', async () => {
@@ -235,8 +238,7 @@ describe('httpClient', () => {
       }),
     ).rejects.toThrow('Refresh token inexistente.');
 
-    expect(mockPost).not.toHaveBeenCalled();
+    expect(axiosMock.__mockPost).not.toHaveBeenCalled();
     expect(localStorage.getItem('access_token')).toBeNull();
-    expect(globalThis.location.href).toBe('/login');
   });
 });

--- a/src/shared/api/httpClient.test.ts
+++ b/src/shared/api/httpClient.test.ts
@@ -2,21 +2,79 @@ jest.mock('../config/env', () => ({
   API_BASE_URL: 'https://api.test',
 }));
 
+const mockPost = jest.fn();
+const mockMainClientRequest = jest.fn();
+
+type InterceptorPair = {
+  fulfilled: (value: unknown) => unknown;
+  rejected?: (error: unknown) => unknown;
+};
+
+jest.mock('axios', () => {
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn((config) => {
+        const client = Object.assign(jest.fn(mockMainClientRequest), {
+          defaults: { baseURL: config.baseURL },
+          interceptors: {
+            request: {
+              handlers: [] as InterceptorPair[],
+              use: jest.fn((fulfilled, rejected) => {
+                client.interceptors.request.handlers.push({ fulfilled, rejected });
+              }),
+            },
+            response: {
+              handlers: [] as InterceptorPair[],
+              use: jest.fn((fulfilled, rejected) => {
+                client.interceptors.response.handlers.push({ fulfilled, rejected });
+              }),
+            },
+          },
+          post: mockPost,
+        });
+
+        return client;
+      }),
+    },
+  };
+});
+
 import type { InternalAxiosRequestConfig } from 'axios';
 import { httpClient } from './httpClient';
 
-type RequestInterceptor = {
-  fulfilled: (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>;
+const getRequestInterceptor = () => {
+  const requestInterceptors = httpClient.interceptors.request as unknown as {
+    handlers: InterceptorPair[];
+  };
+  return requestInterceptors.handlers[0].fulfilled;
 };
 
-const runRequestInterceptor = async (config: InternalAxiosRequestConfig) => {
-  const requestInterceptors = httpClient.interceptors.request as unknown as { handlers: RequestInterceptor[] };
-  return requestInterceptors.handlers[0].fulfilled(config);
+const getResponseErrorInterceptor = () => {
+  const responseInterceptors = httpClient.interceptors.response as unknown as {
+    handlers: InterceptorPair[];
+  };
+  const rejected = responseInterceptors.handlers[0].rejected;
+
+  if (!rejected) {
+    throw new Error('Response error interceptor nao registrado.');
+  }
+
+  return rejected;
 };
 
 describe('httpClient', () => {
-  afterEach(() => {
+  beforeEach(() => {
     localStorage.clear();
+    mockPost.mockReset();
+    mockMainClientRequest.mockReset();
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: {
+        pathname: '/home',
+        href: '/home',
+      },
+    });
   });
 
   it('uses the configured API base URL', () => {
@@ -26,18 +84,159 @@ describe('httpClient', () => {
   it('adds the bearer token to requests when it exists', async () => {
     localStorage.setItem('access_token', 'access-token');
 
-    const config = await runRequestInterceptor({
+    const config = await getRequestInterceptor()({
       headers: {} as InternalAxiosRequestConfig['headers'],
-    } as InternalAxiosRequestConfig);
+    } as InternalAxiosRequestConfig) as InternalAxiosRequestConfig;
 
     expect(config.headers.Authorization).toBe('Bearer access-token');
   });
 
   it('keeps requests untouched when no token is stored', async () => {
-    const config = await runRequestInterceptor({
+    const config = await getRequestInterceptor()({
       headers: {} as InternalAxiosRequestConfig['headers'],
-    } as InternalAxiosRequestConfig);
+    } as InternalAxiosRequestConfig) as InternalAxiosRequestConfig;
 
     expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it('renews tokens and retries the original request on 401', async () => {
+    localStorage.setItem('refresh_token', 'refresh-token-antigo');
+    mockPost.mockResolvedValueOnce({
+      data: {
+        dados: {
+          accessToken: 'novo-access-token',
+          refreshToken: 'novo-refresh-token',
+        },
+      },
+    });
+    mockMainClientRequest.mockResolvedValueOnce({ data: { ok: true } });
+    const originalRequest = {
+      url: '/auth/me',
+      headers: {},
+    };
+
+    await expect(
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: originalRequest,
+      }),
+    ).resolves.toEqual({ data: { ok: true } });
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/refresh', {
+      refreshToken: 'refresh-token-antigo',
+    });
+    expect(localStorage.getItem('access_token')).toBe('novo-access-token');
+    expect(localStorage.getItem('refresh_token')).toBe('novo-refresh-token');
+    expect(originalRequest.headers).toEqual({
+      Authorization: 'Bearer novo-access-token',
+    });
+    expect(originalRequest).toMatchObject({ _retry: true });
+    expect(mockMainClientRequest).toHaveBeenCalledWith(originalRequest);
+  });
+
+  it('shares the same refresh request between concurrent 401 responses', async () => {
+    localStorage.setItem('refresh_token', 'refresh-token-antigo');
+    mockPost.mockResolvedValueOnce({
+      data: {
+        dados: {
+          accessToken: 'novo-access-token',
+          refreshToken: 'novo-refresh-token',
+        },
+      },
+    });
+    mockMainClientRequest
+      .mockResolvedValueOnce({ data: { request: 1 } })
+      .mockResolvedValueOnce({ data: { request: 2 } });
+    const firstRequest = {
+      url: '/auth/me',
+      headers: {},
+    };
+    const secondRequest = {
+      url: '/quizzes',
+      headers: {},
+    };
+
+    await Promise.all([
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: firstRequest,
+      }),
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: secondRequest,
+      }),
+    ]);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(firstRequest.headers).toEqual({ Authorization: 'Bearer novo-access-token' });
+    expect(secondRequest.headers).toEqual({ Authorization: 'Bearer novo-access-token' });
+    expect(mockMainClientRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not try to refresh login or refresh requests', async () => {
+    const loginError = {
+      response: { status: 401 },
+      config: { url: '/auth/login', headers: {} },
+    };
+    const refreshError = {
+      response: { status: 401 },
+      config: { url: '/auth/refresh', headers: {} },
+    };
+
+    await expect(getResponseErrorInterceptor()(loginError)).rejects.toBe(loginError);
+    await expect(getResponseErrorInterceptor()(refreshError)).rejects.toBe(refreshError);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a request more than once', async () => {
+    const error = {
+      response: { status: 401 },
+      config: { url: '/auth/me', headers: {}, _retry: true },
+    };
+
+    await expect(getResponseErrorInterceptor()(error)).rejects.toBe(error);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('does not try to refresh non 401 errors', async () => {
+    const error = {
+      response: { status: 500 },
+      config: { url: '/auth/me', headers: {} },
+    };
+
+    await expect(getResponseErrorInterceptor()(error)).rejects.toBe(error);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('clears tokens and redirects to login when refresh fails', async () => {
+    localStorage.setItem('access_token', 'access-token');
+    localStorage.setItem('refresh_token', 'refresh-token');
+    mockPost.mockRejectedValueOnce(new Error('refresh falhou'));
+
+    await expect(
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: { url: '/auth/me', headers: {} },
+      }),
+    ).rejects.toThrow('refresh falhou');
+
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+    expect(globalThis.location.href).toBe('/login');
+  });
+
+  it('clears tokens and redirects to login when there is no refresh token', async () => {
+    localStorage.setItem('access_token', 'access-token');
+
+    await expect(
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: { url: '/auth/me', headers: {} },
+      }),
+    ).rejects.toThrow('Refresh token inexistente.');
+
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(globalThis.location.href).toBe('/login');
   });
 });

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -1,15 +1,111 @@
 import axios from 'axios';
+import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { API_BASE_URL } from '../config/env';
+
+const ACCESS_TOKEN_KEY = 'access_token';
+const REFRESH_TOKEN_KEY = 'refresh_token';
+
+type RetriableRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+};
+
+type RefreshResponse = {
+  dados: {
+    accessToken: string;
+    refreshToken: string;
+  };
+};
 
 export const httpClient = axios.create({
   baseURL: API_BASE_URL,
   headers: { 'Content-Type': 'application/json' },
 });
 
+const refreshClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+let refreshPromise: Promise<string> | null = null;
+
+const clearAuthTokens = () => {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+};
+
+const redirectToLogin = () => {
+  if (globalThis.location.pathname !== '/login') {
+    globalThis.location.href = '/login';
+  }
+};
+
+const isAuthEndpoint = (url?: string) => (
+  url?.includes('/auth/login') || url?.includes('/auth/refresh')
+);
+
+const refreshTokens = async () => {
+  const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+
+  if (!refreshToken) {
+    throw new Error('Refresh token inexistente.');
+  }
+
+  const { data } = await refreshClient.post<RefreshResponse>('/auth/refresh', {
+    refreshToken,
+  });
+
+  localStorage.setItem(ACCESS_TOKEN_KEY, data.dados.accessToken);
+  localStorage.setItem(REFRESH_TOKEN_KEY, data.dados.refreshToken);
+
+  return data.dados.accessToken;
+};
+
+const getFreshAccessToken = () => {
+  if (!refreshPromise) {
+    refreshPromise = refreshTokens().finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  return refreshPromise;
+};
+
 httpClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem('access_token');
+  const token = localStorage.getItem(ACCESS_TOKEN_KEY);
   if (token && config.headers) {
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });
+
+httpClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as RetriableRequestConfig | undefined;
+
+    if (
+      error.response?.status !== 401 ||
+      !originalRequest ||
+      originalRequest._retry ||
+      isAuthEndpoint(originalRequest.url)
+    ) {
+      return Promise.reject(error);
+    }
+
+    originalRequest._retry = true;
+
+    try {
+      const accessToken = await getFreshAccessToken();
+
+      if (originalRequest.headers) {
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+      }
+
+      return httpClient(originalRequest) as Promise<AxiosResponse>;
+    } catch (refreshError) {
+      clearAuthTokens();
+      redirectToLogin();
+      return Promise.reject(refreshError);
+    }
+  },
+);


### PR DESCRIPTION
## Descrição

Implementa a renovação automática de sessão no frontend usando interceptor do Axios.

Quando uma requisição retorna `401` por access token inválido/expirado, o frontend chama `/auth/refresh`, atualiza os tokens no `localStorage` e reenvia automaticamente a requisição original.

## Rastreabilidade

Issue(s) Relacionada(s):

Closes #10 
Relates to #14

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [x] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Evidências (se aplicável)

- `GET /auth/me` retorna `401` com access token inválido
- Interceptor chama `POST /auth/refresh`
- Tokens são atualizados no `localStorage`
- Requisição original é reenviada com sucesso
<img width="882" height="145" alt="image" src="https://github.com/user-attachments/assets/3bad799e-a1db-491f-bf68-adc9b97f2655" />

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

O interceptor ignora `/auth/login` e `/auth/refresh` para evitar loop infinito.

Também foi adicionada uma `refreshPromise` compartilhada para evitar múltiplas chamadas simultâneas ao refresh quando várias requisições retornam `401` ao mesmo tempo.