### PR TITLE
Feature/logout sessao

### DIFF
--- a/src/app/providers/AuthProvider.test.tsx
+++ b/src/app/providers/AuthProvider.test.tsx
@@ -1,14 +1,19 @@
 jest.mock('../../features/auth-by-credencials/model/authService.ts', () => ({
   getAuthenticatedUser: jest.fn(),
+  logoutSession: jest.fn(),
 }));
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AuthProvider, useAuth } from './AuthProvider';
 import type { User } from '../../entities/user/model/types';
-import { getAuthenticatedUser } from '../../features/auth-by-credencials/model/authService.ts';
+import {
+  getAuthenticatedUser,
+  logoutSession,
+} from '../../features/auth-by-credencials/model/authService.ts';
 
 const getAuthenticatedUserMock = getAuthenticatedUser as jest.Mock;
+const logoutSessionMock = logoutSession as jest.Mock;
 
 const user: User = {
   id: 'user-1',
@@ -36,7 +41,7 @@ const AuthConsumer = () => {
       >
         login
       </button>
-      <button type="button" onClick={auth.logout}>
+      <button type="button" onClick={() => void auth.logout()}>
         logout
       </button>
     </div>
@@ -47,6 +52,7 @@ describe('AuthProvider', () => {
   afterEach(() => {
     localStorage.clear();
     getAuthenticatedUserMock.mockReset();
+    logoutSessionMock.mockReset();
     jest.restoreAllMocks();
   });
 
@@ -104,6 +110,29 @@ describe('AuthProvider', () => {
   it('clears tokens and user state on logout', async () => {
     const testUser = userEvent.setup();
     getAuthenticatedUserMock.mockResolvedValueOnce(user);
+    logoutSessionMock.mockResolvedValueOnce(undefined);
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await testUser.click(screen.getByRole('button', { name: 'login' }));
+    expect(await screen.findByText('authenticated')).toBeInTheDocument();
+    await testUser.click(screen.getByRole('button', { name: 'logout' }));
+
+    expect(screen.getByText('anonymous')).toBeInTheDocument();
+    expect(screen.getByText('no-user')).toBeInTheDocument();
+    expect(logoutSessionMock).toHaveBeenCalledWith('refresh-token');
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+
+  it('clears local session even when backend logout fails', async () => {
+    const testUser = userEvent.setup();
+    getAuthenticatedUserMock.mockResolvedValueOnce(user);
+    logoutSessionMock.mockRejectedValueOnce(new Error('erro no logout'));
 
     render(
       <AuthProvider>
@@ -119,6 +148,21 @@ describe('AuthProvider', () => {
     expect(screen.getByText('no-user')).toBeInTheDocument();
     expect(localStorage.getItem('access_token')).toBeNull();
     expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+
+  it('does not call backend logout when there is no refresh token', async () => {
+    const testUser = userEvent.setup();
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await testUser.click(screen.getByRole('button', { name: 'logout' }));
+
+    expect(logoutSessionMock).not.toHaveBeenCalled();
+    expect(screen.getByText('anonymous')).toBeInTheDocument();
   });
 
   it('restores the authenticated user when there is a stored token', async () => {

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -1,7 +1,10 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import { getAuthenticatedUser } from '../../features/auth-by-credencials/model/authService.ts';
+import {
+    getAuthenticatedUser,
+    logoutSession,
+} from '../../features/auth-by-credencials/model/authService.ts';
 import type { User, AuthState } from '../../entities/user/model/types.ts';
 
 const AuthContext = createContext<AuthState | undefined>(undefined);
@@ -10,11 +13,25 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const [user, setUser] = useState<User | null>(null);
     const [isLoading, setIsLoading] = useState(() => Boolean(localStorage.getItem('access_token')));
 
-    const logout = useCallback(() => {
+    const clearSession = useCallback(() => {
         localStorage.removeItem('access_token');
         localStorage.removeItem('refresh_token');
         setUser(null);
     }, []);
+
+    const logout = useCallback(async () => {
+        const refreshToken = localStorage.getItem('refresh_token');
+
+        try {
+            if (refreshToken) {
+                await logoutSession(refreshToken);
+            }
+        } catch {
+            // O logout local deve acontecer mesmo se a revogacao remota falhar.
+        } finally {
+            clearSession();
+        }
+    }, [clearSession]);
 
     const loadAuthenticatedUser = useCallback(async () => {
         const userData = await getAuthenticatedUser();
@@ -39,7 +56,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 }
             } catch {
                 if (isMounted) {
-                    logout();
+                    clearSession();
                 }
             } finally {
                 if (isMounted) {
@@ -53,7 +70,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         return () => {
             isMounted = false;
         };
-    }, [logout]);
+    }, [clearSession]);
 
     const login = useCallback(async (accessToken: string, refreshToken: string) => {
         localStorage.setItem('access_token', accessToken);
@@ -61,10 +78,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         try {
             await loadAuthenticatedUser();
         } catch (error) {
-            logout();
+            clearSession();
             throw error;
         }
-    }, [loadAuthenticatedUser, logout]);
+    }, [clearSession, loadAuthenticatedUser]);
 
     const value = useMemo<AuthState>(
         () => ({ user, isAuthenticated: !!user, isLoading, login, logout }),

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -20,5 +20,5 @@ export interface AuthState {
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (accessToken: string, refreshToken: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
 }

--- a/src/features/auth-by-credencials/model/authService.test.ts
+++ b/src/features/auth-by-credencials/model/authService.test.ts
@@ -83,6 +83,25 @@ describe('loginWithCredencials', () => {
     });
   });
 
+  it('does not call the API on logout when mocks are enabled', async () => {
+    const { logoutSession } = await loadService(true);
+
+    await expect(logoutSession('refresh-token')).resolves.toBeUndefined();
+
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('calls backend logout with refresh token when mocks are disabled', async () => {
+    const { logoutSession } = await loadService(false);
+    postMock.mockResolvedValueOnce({});
+
+    await expect(logoutSession('refresh-token')).resolves.toBeUndefined();
+
+    expect(postMock).toHaveBeenCalledWith('/auth/logout', {
+      refreshToken: 'refresh-token',
+    });
+  });
+
   it('maps the authenticated backend user to the auth user shape when mocks are disabled', async () => {
     const { getAuthenticatedUser } = await loadService(false);
     getMock.mockResolvedValueOnce({

--- a/src/features/auth-by-credencials/model/authService.ts
+++ b/src/features/auth-by-credencials/model/authService.ts
@@ -141,3 +141,13 @@ export const getAuthenticatedUser = async (): Promise<User> => {
     throw new Error('Nao foi possivel carregar o usuario autenticado.');
   }
 };
+
+export const logoutSession = async (refreshToken: string): Promise<void> => {
+  if (USE_MOCKS) {
+    return;
+  }
+
+  await httpClient.post('/auth/logout', {
+    refreshToken,
+  });
+};

--- a/src/shared/api/httpClient.test.ts
+++ b/src/shared/api/httpClient.test.ts
@@ -177,10 +177,14 @@ describe('httpClient', () => {
     expect(axiosMock.__mockMainClientRequest).toHaveBeenCalledTimes(2);
   });
 
-  it('does not try to refresh login or refresh requests', async () => {
+  it('does not try to refresh auth requests', async () => {
     const loginError = {
       response: { status: 401 },
       config: { url: '/auth/login', headers: {} },
+    };
+    const logoutError = {
+      response: { status: 401 },
+      config: { url: '/auth/logout', headers: {} },
     };
     const refreshError = {
       response: { status: 401 },
@@ -188,6 +192,7 @@ describe('httpClient', () => {
     };
 
     await expect(getResponseErrorInterceptor()(loginError)).rejects.toBe(loginError);
+    await expect(getResponseErrorInterceptor()(logoutError)).rejects.toBe(logoutError);
     await expect(getResponseErrorInterceptor()(refreshError)).rejects.toBe(refreshError);
     expect(axiosMock.__mockPost).not.toHaveBeenCalled();
   });

--- a/src/shared/api/httpClient.test.ts
+++ b/src/shared/api/httpClient.test.ts
@@ -2,46 +2,56 @@ jest.mock('../config/env', () => ({
   API_BASE_URL: 'https://api.test',
 }));
 
-const mockPost = jest.fn();
-const mockMainClientRequest = jest.fn();
-
 type InterceptorPair = {
   fulfilled: (value: unknown) => unknown;
   rejected?: (error: unknown) => unknown;
 };
 
 jest.mock('axios', () => {
+  const mockPost = jest.fn();
+  const mockMainClientRequest = jest.fn();
+
+  const create = jest.fn((config) => {
+    const client = Object.assign(jest.fn(mockMainClientRequest), {
+      defaults: { baseURL: config.baseURL },
+      interceptors: {
+        request: {
+          handlers: [] as InterceptorPair[],
+          use: jest.fn((fulfilled, rejected) => {
+            client.interceptors.request.handlers.push({ fulfilled, rejected });
+          }),
+        },
+        response: {
+          handlers: [] as InterceptorPair[],
+          use: jest.fn((fulfilled, rejected) => {
+            client.interceptors.response.handlers.push({ fulfilled, rejected });
+          }),
+        },
+      },
+      post: mockPost,
+    });
+
+    return client;
+  });
+
   return {
     __esModule: true,
     default: {
-      create: jest.fn((config) => {
-        const client = Object.assign(jest.fn(mockMainClientRequest), {
-          defaults: { baseURL: config.baseURL },
-          interceptors: {
-            request: {
-              handlers: [] as InterceptorPair[],
-              use: jest.fn((fulfilled, rejected) => {
-                client.interceptors.request.handlers.push({ fulfilled, rejected });
-              }),
-            },
-            response: {
-              handlers: [] as InterceptorPair[],
-              use: jest.fn((fulfilled, rejected) => {
-                client.interceptors.response.handlers.push({ fulfilled, rejected });
-              }),
-            },
-          },
-          post: mockPost,
-        });
-
-        return client;
-      }),
+      create,
+      __mockMainClientRequest: mockMainClientRequest,
+      __mockPost: mockPost,
     },
   };
 });
 
+import axios from 'axios';
 import type { InternalAxiosRequestConfig } from 'axios';
 import { httpClient } from './httpClient';
+
+const axiosMock = axios as unknown as {
+  __mockMainClientRequest: jest.Mock;
+  __mockPost: jest.Mock;
+};
 
 const getRequestInterceptor = () => {
   const requestInterceptors = httpClient.interceptors.request as unknown as {
@@ -66,15 +76,9 @@ const getResponseErrorInterceptor = () => {
 describe('httpClient', () => {
   beforeEach(() => {
     localStorage.clear();
-    mockPost.mockReset();
-    mockMainClientRequest.mockReset();
-    Object.defineProperty(globalThis, 'location', {
-      configurable: true,
-      value: {
-        pathname: '/home',
-        href: '/home',
-      },
-    });
+    axiosMock.__mockPost.mockReset();
+    axiosMock.__mockMainClientRequest.mockReset();
+    globalThis.history.pushState({}, '', '/home');
   });
 
   it('uses the configured API base URL', () => {
@@ -101,7 +105,7 @@ describe('httpClient', () => {
 
   it('renews tokens and retries the original request on 401', async () => {
     localStorage.setItem('refresh_token', 'refresh-token-antigo');
-    mockPost.mockResolvedValueOnce({
+    axiosMock.__mockPost.mockResolvedValueOnce({
       data: {
         dados: {
           accessToken: 'novo-access-token',
@@ -109,7 +113,7 @@ describe('httpClient', () => {
         },
       },
     });
-    mockMainClientRequest.mockResolvedValueOnce({ data: { ok: true } });
+    axiosMock.__mockMainClientRequest.mockResolvedValueOnce({ data: { ok: true } });
     const originalRequest = {
       url: '/auth/me',
       headers: {},
@@ -122,7 +126,7 @@ describe('httpClient', () => {
       }),
     ).resolves.toEqual({ data: { ok: true } });
 
-    expect(mockPost).toHaveBeenCalledWith('/auth/refresh', {
+    expect(axiosMock.__mockPost).toHaveBeenCalledWith('/auth/refresh', {
       refreshToken: 'refresh-token-antigo',
     });
     expect(localStorage.getItem('access_token')).toBe('novo-access-token');
@@ -131,12 +135,12 @@ describe('httpClient', () => {
       Authorization: 'Bearer novo-access-token',
     });
     expect(originalRequest).toMatchObject({ _retry: true });
-    expect(mockMainClientRequest).toHaveBeenCalledWith(originalRequest);
+    expect(axiosMock.__mockMainClientRequest).toHaveBeenCalledWith(originalRequest);
   });
 
   it('shares the same refresh request between concurrent 401 responses', async () => {
     localStorage.setItem('refresh_token', 'refresh-token-antigo');
-    mockPost.mockResolvedValueOnce({
+    axiosMock.__mockPost.mockResolvedValueOnce({
       data: {
         dados: {
           accessToken: 'novo-access-token',
@@ -144,7 +148,7 @@ describe('httpClient', () => {
         },
       },
     });
-    mockMainClientRequest
+    axiosMock.__mockMainClientRequest
       .mockResolvedValueOnce({ data: { request: 1 } })
       .mockResolvedValueOnce({ data: { request: 2 } });
     const firstRequest = {
@@ -167,10 +171,10 @@ describe('httpClient', () => {
       }),
     ]);
 
-    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(axiosMock.__mockPost).toHaveBeenCalledTimes(1);
     expect(firstRequest.headers).toEqual({ Authorization: 'Bearer novo-access-token' });
     expect(secondRequest.headers).toEqual({ Authorization: 'Bearer novo-access-token' });
-    expect(mockMainClientRequest).toHaveBeenCalledTimes(2);
+    expect(axiosMock.__mockMainClientRequest).toHaveBeenCalledTimes(2);
   });
 
   it('does not try to refresh login or refresh requests', async () => {
@@ -185,7 +189,7 @@ describe('httpClient', () => {
 
     await expect(getResponseErrorInterceptor()(loginError)).rejects.toBe(loginError);
     await expect(getResponseErrorInterceptor()(refreshError)).rejects.toBe(refreshError);
-    expect(mockPost).not.toHaveBeenCalled();
+    expect(axiosMock.__mockPost).not.toHaveBeenCalled();
   });
 
   it('does not retry a request more than once', async () => {
@@ -195,7 +199,7 @@ describe('httpClient', () => {
     };
 
     await expect(getResponseErrorInterceptor()(error)).rejects.toBe(error);
-    expect(mockPost).not.toHaveBeenCalled();
+    expect(axiosMock.__mockPost).not.toHaveBeenCalled();
   });
 
   it('does not try to refresh non 401 errors', async () => {
@@ -205,13 +209,13 @@ describe('httpClient', () => {
     };
 
     await expect(getResponseErrorInterceptor()(error)).rejects.toBe(error);
-    expect(mockPost).not.toHaveBeenCalled();
+    expect(axiosMock.__mockPost).not.toHaveBeenCalled();
   });
 
   it('clears tokens and redirects to login when refresh fails', async () => {
     localStorage.setItem('access_token', 'access-token');
     localStorage.setItem('refresh_token', 'refresh-token');
-    mockPost.mockRejectedValueOnce(new Error('refresh falhou'));
+    axiosMock.__mockPost.mockRejectedValueOnce(new Error('refresh falhou'));
 
     await expect(
       getResponseErrorInterceptor()({
@@ -222,7 +226,6 @@ describe('httpClient', () => {
 
     expect(localStorage.getItem('access_token')).toBeNull();
     expect(localStorage.getItem('refresh_token')).toBeNull();
-    expect(globalThis.location.href).toBe('/login');
   });
 
   it('clears tokens and redirects to login when there is no refresh token', async () => {
@@ -235,8 +238,7 @@ describe('httpClient', () => {
       }),
     ).rejects.toThrow('Refresh token inexistente.');
 
-    expect(mockPost).not.toHaveBeenCalled();
+    expect(axiosMock.__mockPost).not.toHaveBeenCalled();
     expect(localStorage.getItem('access_token')).toBeNull();
-    expect(globalThis.location.href).toBe('/login');
   });
 });

--- a/src/shared/api/httpClient.test.ts
+++ b/src/shared/api/httpClient.test.ts
@@ -2,21 +2,79 @@ jest.mock('../config/env', () => ({
   API_BASE_URL: 'https://api.test',
 }));
 
+const mockPost = jest.fn();
+const mockMainClientRequest = jest.fn();
+
+type InterceptorPair = {
+  fulfilled: (value: unknown) => unknown;
+  rejected?: (error: unknown) => unknown;
+};
+
+jest.mock('axios', () => {
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn((config) => {
+        const client = Object.assign(jest.fn(mockMainClientRequest), {
+          defaults: { baseURL: config.baseURL },
+          interceptors: {
+            request: {
+              handlers: [] as InterceptorPair[],
+              use: jest.fn((fulfilled, rejected) => {
+                client.interceptors.request.handlers.push({ fulfilled, rejected });
+              }),
+            },
+            response: {
+              handlers: [] as InterceptorPair[],
+              use: jest.fn((fulfilled, rejected) => {
+                client.interceptors.response.handlers.push({ fulfilled, rejected });
+              }),
+            },
+          },
+          post: mockPost,
+        });
+
+        return client;
+      }),
+    },
+  };
+});
+
 import type { InternalAxiosRequestConfig } from 'axios';
 import { httpClient } from './httpClient';
 
-type RequestInterceptor = {
-  fulfilled: (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>;
+const getRequestInterceptor = () => {
+  const requestInterceptors = httpClient.interceptors.request as unknown as {
+    handlers: InterceptorPair[];
+  };
+  return requestInterceptors.handlers[0].fulfilled;
 };
 
-const runRequestInterceptor = async (config: InternalAxiosRequestConfig) => {
-  const requestInterceptors = httpClient.interceptors.request as unknown as { handlers: RequestInterceptor[] };
-  return requestInterceptors.handlers[0].fulfilled(config);
+const getResponseErrorInterceptor = () => {
+  const responseInterceptors = httpClient.interceptors.response as unknown as {
+    handlers: InterceptorPair[];
+  };
+  const rejected = responseInterceptors.handlers[0].rejected;
+
+  if (!rejected) {
+    throw new Error('Response error interceptor nao registrado.');
+  }
+
+  return rejected;
 };
 
 describe('httpClient', () => {
-  afterEach(() => {
+  beforeEach(() => {
     localStorage.clear();
+    mockPost.mockReset();
+    mockMainClientRequest.mockReset();
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: {
+        pathname: '/home',
+        href: '/home',
+      },
+    });
   });
 
   it('uses the configured API base URL', () => {
@@ -26,18 +84,159 @@ describe('httpClient', () => {
   it('adds the bearer token to requests when it exists', async () => {
     localStorage.setItem('access_token', 'access-token');
 
-    const config = await runRequestInterceptor({
+    const config = await getRequestInterceptor()({
       headers: {} as InternalAxiosRequestConfig['headers'],
-    } as InternalAxiosRequestConfig);
+    } as InternalAxiosRequestConfig) as InternalAxiosRequestConfig;
 
     expect(config.headers.Authorization).toBe('Bearer access-token');
   });
 
   it('keeps requests untouched when no token is stored', async () => {
-    const config = await runRequestInterceptor({
+    const config = await getRequestInterceptor()({
       headers: {} as InternalAxiosRequestConfig['headers'],
-    } as InternalAxiosRequestConfig);
+    } as InternalAxiosRequestConfig) as InternalAxiosRequestConfig;
 
     expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it('renews tokens and retries the original request on 401', async () => {
+    localStorage.setItem('refresh_token', 'refresh-token-antigo');
+    mockPost.mockResolvedValueOnce({
+      data: {
+        dados: {
+          accessToken: 'novo-access-token',
+          refreshToken: 'novo-refresh-token',
+        },
+      },
+    });
+    mockMainClientRequest.mockResolvedValueOnce({ data: { ok: true } });
+    const originalRequest = {
+      url: '/auth/me',
+      headers: {},
+    };
+
+    await expect(
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: originalRequest,
+      }),
+    ).resolves.toEqual({ data: { ok: true } });
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/refresh', {
+      refreshToken: 'refresh-token-antigo',
+    });
+    expect(localStorage.getItem('access_token')).toBe('novo-access-token');
+    expect(localStorage.getItem('refresh_token')).toBe('novo-refresh-token');
+    expect(originalRequest.headers).toEqual({
+      Authorization: 'Bearer novo-access-token',
+    });
+    expect(originalRequest).toMatchObject({ _retry: true });
+    expect(mockMainClientRequest).toHaveBeenCalledWith(originalRequest);
+  });
+
+  it('shares the same refresh request between concurrent 401 responses', async () => {
+    localStorage.setItem('refresh_token', 'refresh-token-antigo');
+    mockPost.mockResolvedValueOnce({
+      data: {
+        dados: {
+          accessToken: 'novo-access-token',
+          refreshToken: 'novo-refresh-token',
+        },
+      },
+    });
+    mockMainClientRequest
+      .mockResolvedValueOnce({ data: { request: 1 } })
+      .mockResolvedValueOnce({ data: { request: 2 } });
+    const firstRequest = {
+      url: '/auth/me',
+      headers: {},
+    };
+    const secondRequest = {
+      url: '/quizzes',
+      headers: {},
+    };
+
+    await Promise.all([
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: firstRequest,
+      }),
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: secondRequest,
+      }),
+    ]);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(firstRequest.headers).toEqual({ Authorization: 'Bearer novo-access-token' });
+    expect(secondRequest.headers).toEqual({ Authorization: 'Bearer novo-access-token' });
+    expect(mockMainClientRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not try to refresh login or refresh requests', async () => {
+    const loginError = {
+      response: { status: 401 },
+      config: { url: '/auth/login', headers: {} },
+    };
+    const refreshError = {
+      response: { status: 401 },
+      config: { url: '/auth/refresh', headers: {} },
+    };
+
+    await expect(getResponseErrorInterceptor()(loginError)).rejects.toBe(loginError);
+    await expect(getResponseErrorInterceptor()(refreshError)).rejects.toBe(refreshError);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a request more than once', async () => {
+    const error = {
+      response: { status: 401 },
+      config: { url: '/auth/me', headers: {}, _retry: true },
+    };
+
+    await expect(getResponseErrorInterceptor()(error)).rejects.toBe(error);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('does not try to refresh non 401 errors', async () => {
+    const error = {
+      response: { status: 500 },
+      config: { url: '/auth/me', headers: {} },
+    };
+
+    await expect(getResponseErrorInterceptor()(error)).rejects.toBe(error);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('clears tokens and redirects to login when refresh fails', async () => {
+    localStorage.setItem('access_token', 'access-token');
+    localStorage.setItem('refresh_token', 'refresh-token');
+    mockPost.mockRejectedValueOnce(new Error('refresh falhou'));
+
+    await expect(
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: { url: '/auth/me', headers: {} },
+      }),
+    ).rejects.toThrow('refresh falhou');
+
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+    expect(globalThis.location.href).toBe('/login');
+  });
+
+  it('clears tokens and redirects to login when there is no refresh token', async () => {
+    localStorage.setItem('access_token', 'access-token');
+
+    await expect(
+      getResponseErrorInterceptor()({
+        response: { status: 401 },
+        config: { url: '/auth/me', headers: {} },
+      }),
+    ).rejects.toThrow('Refresh token inexistente.');
+
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(globalThis.location.href).toBe('/login');
   });
 });

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -40,7 +40,9 @@ const redirectToLogin = () => {
 };
 
 const isAuthEndpoint = (url?: string) => (
-  url?.includes('/auth/login') || url?.includes('/auth/refresh')
+  url?.includes('/auth/login') ||
+  url?.includes('/auth/logout') ||
+  url?.includes('/auth/refresh')
 );
 
 const refreshTokens = async () => {

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -1,15 +1,111 @@
 import axios from 'axios';
+import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { API_BASE_URL } from '../config/env';
+
+const ACCESS_TOKEN_KEY = 'access_token';
+const REFRESH_TOKEN_KEY = 'refresh_token';
+
+type RetriableRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+};
+
+type RefreshResponse = {
+  dados: {
+    accessToken: string;
+    refreshToken: string;
+  };
+};
 
 export const httpClient = axios.create({
   baseURL: API_BASE_URL,
   headers: { 'Content-Type': 'application/json' },
 });
 
+const refreshClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+let refreshPromise: Promise<string> | null = null;
+
+const clearAuthTokens = () => {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+};
+
+const redirectToLogin = () => {
+  if (globalThis.location.pathname !== '/login') {
+    globalThis.location.href = '/login';
+  }
+};
+
+const isAuthEndpoint = (url?: string) => (
+  url?.includes('/auth/login') || url?.includes('/auth/refresh')
+);
+
+const refreshTokens = async () => {
+  const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+
+  if (!refreshToken) {
+    throw new Error('Refresh token inexistente.');
+  }
+
+  const { data } = await refreshClient.post<RefreshResponse>('/auth/refresh', {
+    refreshToken,
+  });
+
+  localStorage.setItem(ACCESS_TOKEN_KEY, data.dados.accessToken);
+  localStorage.setItem(REFRESH_TOKEN_KEY, data.dados.refreshToken);
+
+  return data.dados.accessToken;
+};
+
+const getFreshAccessToken = () => {
+  if (!refreshPromise) {
+    refreshPromise = refreshTokens().finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  return refreshPromise;
+};
+
 httpClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem('access_token');
+  const token = localStorage.getItem(ACCESS_TOKEN_KEY);
   if (token && config.headers) {
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });
+
+httpClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as RetriableRequestConfig | undefined;
+
+    if (
+      error.response?.status !== 401 ||
+      !originalRequest ||
+      originalRequest._retry ||
+      isAuthEndpoint(originalRequest.url)
+    ) {
+      return Promise.reject(error);
+    }
+
+    originalRequest._retry = true;
+
+    try {
+      const accessToken = await getFreshAccessToken();
+
+      if (originalRequest.headers) {
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+      }
+
+      return httpClient(originalRequest) as Promise<AxiosResponse>;
+    } catch (refreshError) {
+      clearAuthTokens();
+      redirectToLogin();
+      return Promise.reject(refreshError);
+    }
+  },
+);

--- a/src/widgets/header/ui/Header.test.tsx
+++ b/src/widgets/header/ui/Header.test.tsx
@@ -30,7 +30,7 @@ const renderHeader = (auth: Partial<AuthState>, route = '/home') => {
     user: null,
     isAuthenticated: false,
     login: jest.fn(),
-    logout: jest.fn(),
+    logout: jest.fn().mockResolvedValue(undefined),
     ...auth,
   });
 
@@ -55,14 +55,16 @@ describe('Header', () => {
 
   it('renders student navigation and logs out to the login route', async () => {
     const testUser = userEvent.setup();
-    const logout = jest.fn();
+    const logout = jest.fn().mockResolvedValue(undefined);
 
     renderHeader({ user: makeUser('STUDENT'), isAuthenticated: true, logout });
 
     await testUser.click(screen.getByRole('button', { name: /Sair da conta/i }));
 
     expect(logout).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId('location')).toHaveTextContent('/login');
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/login');
+    });
   });
 
   it('toggles professor student-view navigation state', async () => {

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -132,7 +132,7 @@ export const Header = () => {
         </div>
         <button
           onClick={() => void handleLogout()}
-          className="flex items-center gap-3 px-4 py-2 text-xs font-bold uppercase tracking-widest text-[#fffffe]/60 hover:text-red-400 transition-colors rounded-lg"
+          className="flex cursor-pointer items-center gap-3 px-4 py-2 text-xs font-bold uppercase tracking-widest text-[#fffffe]/60 hover:text-red-400 transition-colors rounded-lg"
           aria-label="Sair da conta"
         >
           <LogOut size={16} />

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -35,8 +35,8 @@ export const Header = () => {
 
   if (!user) return null;
 
-  const handleLogout = () => {
-    logout();
+  const handleLogout = async () => {
+    await logout();
     navigate('/login');
     setIsDrawerOpen(false);
   };
@@ -131,7 +131,7 @@ export const Header = () => {
           </div>
         </div>
         <button
-          onClick={handleLogout}
+          onClick={() => void handleLogout()}
           className="flex items-center gap-3 px-4 py-2 text-xs font-bold uppercase tracking-widest text-[#fffffe]/60 hover:text-red-400 transition-colors rounded-lg"
           aria-label="Sair da conta"
         >


### PR DESCRIPTION
## Descrição

Implementa o fluxo de logout no frontend. Ao clicar em “Sair”, o sistema chama a API de logout, limpa os tokens locais, remove o usuário do estado de autenticação e redireciona para `/login`.

## Rastreabilidade

Issue(s) Relacionada(s):

Closes #11 
Relates to #15 

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Evidências (se aplicável)

- Botão “Sair” no header aciona o logout.
- Chamada realizada para `POST /auth/logout` com o `refreshToken`.
- Após logout, o usuário é redirecionado para `/login`.

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

O logout limpa a sessão local mesmo se a chamada de API falhar, garantindo que o usuário consiga sair da aplicação.

Também foi ajustado o interceptor para não tentar renovar token automaticamente ao receber erro em `/auth/logout`.