### PR TITLE
feat: implementa fluxo de recuperacao de senha no frontend

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -32,6 +32,14 @@ jest.mock('../pages/register/index', () => ({
   RegisterPage: () => <main>Register route</main>,
 }));
 
+jest.mock('../pages/forgot-password', () => ({
+  ForgotPasswordPage: () => <main>Forgot password route</main>,
+}));
+
+jest.mock('../pages/reset-password', () => ({
+  ResetPasswordPage: () => <main>Reset password route</main>,
+}));
+
 const renderAppAt = (path: string) => {
   window.history.pushState({}, '', path);
   return render(<App />);
@@ -52,6 +60,18 @@ describe('App', () => {
     renderAppAt('/cadastro');
 
     expect(screen.getByText('Register route')).toBeInTheDocument();
+  });
+
+  it('renders the forgot password route', () => {
+    renderAppAt('/esqueci-senha');
+
+    expect(screen.getByText('Forgot password route')).toBeInTheDocument();
+  });
+
+  it('renders the reset password route', () => {
+    renderAppAt('/redefinir-senha?token=token');
+
+    expect(screen.getByText('Reset password route')).toBeInTheDocument();
   });
 
   it('redirects unknown routes to home inside the authenticated layout', () => {

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,7 +1,9 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { LoginPage } from '../pages/login/index'; 
-import { HomePage } from '../pages/home/index';  
+import { LoginPage } from '../pages/login/index';
+import { HomePage } from '../pages/home/index';
 import { RegisterPage } from '../pages/register/index';
+import { ForgotPasswordPage } from '../pages/forgot-password';
+import { ResetPasswordPage } from '../pages/reset-password';
 import { AuthenticatedLayout } from './layouts/AuthenticatedLayout';
 import { ProtectedRoute } from './router/ProtectedRoute';
 
@@ -10,6 +12,8 @@ export const AppRouter = () => {
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/cadastro" element={<RegisterPage />} />
+      <Route path="/esqueci-senha" element={<ForgotPasswordPage />} />
+      <Route path="/redefinir-senha" element={<ResetPasswordPage />} />
       <Route element={<ProtectedRoute><AuthenticatedLayout /></ProtectedRoute>}>
         <Route path="/" element={<Navigate to="/home" replace />} />
         <Route path="/home" element={<HomePage />} />

--- a/src/features/recover-password/index.ts
+++ b/src/features/recover-password/index.ts
@@ -1,0 +1,3 @@
+export { ForgotPasswordForm } from './ui/ForgotPasswordForm';
+export { PasswordRecoveryLayout } from './ui/PasswordRecoveryLayout';
+export { ResetPasswordForm } from './ui/ResetPasswordForm';

--- a/src/features/recover-password/model/recoverPasswordService.test.ts
+++ b/src/features/recover-password/model/recoverPasswordService.test.ts
@@ -1,0 +1,86 @@
+jest.mock('../../../shared/api/httpClient', () => ({
+  httpClient: {
+    post: jest.fn(),
+  },
+}));
+
+import { httpClient } from '../../../shared/api/httpClient';
+import {
+  requestPasswordRecovery,
+  resetPassword,
+} from './recoverPasswordService';
+
+const postMock = httpClient.post as jest.Mock;
+
+describe('recoverPasswordService', () => {
+  afterEach(() => {
+    postMock.mockReset();
+  });
+
+  it('requests password recovery and returns backend message', async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        mensagem: 'Se o email existir no sistema, enviamos instrucoes.',
+        dados: null,
+      },
+    });
+
+    await expect(requestPasswordRecovery('aluno@unb.br')).resolves.toBe(
+      'Se o email existir no sistema, enviamos instrucoes.',
+    );
+    expect(postMock).toHaveBeenCalledWith('/auth/forgot-password', {
+      email: 'aluno@unb.br',
+    });
+  });
+
+  it('resets password and returns backend message', async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        mensagem: 'Senha redefinida com sucesso.',
+        dados: null,
+      },
+    });
+
+    await expect(resetPassword('token', 'senha1234')).resolves.toBe(
+      'Senha redefinida com sucesso.',
+    );
+    expect(postMock).toHaveBeenCalledWith('/auth/reset-password', {
+      token: 'token',
+      senha: 'senha1234',
+    });
+  });
+
+  it('throws backend message when password recovery fails', async () => {
+    postMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        data: {
+          erro: {
+            mensagem: 'Falha na validacao da requisicao.',
+          },
+        },
+      },
+    });
+
+    await expect(requestPasswordRecovery('email-invalido')).rejects.toThrow(
+      'Falha na validacao da requisicao.',
+    );
+  });
+
+  it('throws backend message when reset token is invalid', async () => {
+    postMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        data: {
+          erro: {
+            mensagem: 'Link expirado ou invalido.',
+          },
+        },
+      },
+    });
+
+    await expect(resetPassword('token-invalido', 'senha1234')).rejects.toThrow(
+      'Link expirado ou invalido.',
+    );
+  });
+});

--- a/src/features/recover-password/model/recoverPasswordService.ts
+++ b/src/features/recover-password/model/recoverPasswordService.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+import { httpClient } from '../../../shared/api/httpClient';
+
+type BackendMessageResponse = {
+  mensagem: string;
+  dados: null;
+};
+
+const extractErrorMessage = (err: unknown): string | null => {
+  if (!axios.isAxiosError(err) || !err.response) return null;
+
+  const responseData = err.response.data as {
+    message?: string;
+    mensagem?: string;
+    erro?: { mensagem?: string };
+  };
+
+  return responseData.erro?.mensagem ?? responseData.mensagem ?? responseData.message ?? null;
+};
+
+export const requestPasswordRecovery = async (email: string): Promise<string> => {
+  try {
+    const { data } = await httpClient.post<BackendMessageResponse>('/auth/forgot-password', {
+      email,
+    });
+
+    return data.mensagem;
+  } catch (err) {
+    const message = extractErrorMessage(err);
+    throw new Error(message ?? 'Nao foi possivel enviar as instrucoes de recuperacao.');
+  }
+};
+
+export const resetPassword = async (token: string, senha: string): Promise<string> => {
+  try {
+    const { data } = await httpClient.post<BackendMessageResponse>('/auth/reset-password', {
+      token,
+      senha,
+    });
+
+    return data.mensagem;
+  } catch (err) {
+    const message = extractErrorMessage(err);
+    throw new Error(message ?? 'Link expirado ou invalido.');
+  }
+};

--- a/src/features/recover-password/ui/FeedbackMessage.tsx
+++ b/src/features/recover-password/ui/FeedbackMessage.tsx
@@ -11,8 +11,7 @@ export const FeedbackMessage = ({ children, variant }: FeedbackMessageProps) => 
   const Icon = isSuccess ? Check : TriangleAlert;
 
   return (
-    <div
-      role="status"
+    <output
       className={
         'flex w-full items-start gap-2 rounded-[7px] border px-3 py-2 text-xs font-bold leading-relaxed ' +
         (isSuccess
@@ -22,6 +21,6 @@ export const FeedbackMessage = ({ children, variant }: FeedbackMessageProps) => 
     >
       <Icon size={14} className="mt-0.5 shrink-0" />
       <div>{children}</div>
-    </div>
+    </output>
   );
 };

--- a/src/features/recover-password/ui/FeedbackMessage.tsx
+++ b/src/features/recover-password/ui/FeedbackMessage.tsx
@@ -1,0 +1,27 @@
+import { Check, TriangleAlert } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+type FeedbackMessageProps = {
+  children: ReactNode;
+  variant: 'error' | 'success';
+};
+
+export const FeedbackMessage = ({ children, variant }: FeedbackMessageProps) => {
+  const isSuccess = variant === 'success';
+  const Icon = isSuccess ? Check : TriangleAlert;
+
+  return (
+    <div
+      role="status"
+      className={
+        'flex w-full items-start gap-2 rounded-[7px] border px-3 py-2 text-xs font-bold leading-relaxed ' +
+        (isSuccess
+          ? 'border-[#14D5C2] bg-[#14D5C2]/10 text-[#007B6E]'
+          : 'border-red-400 bg-red-50 text-red-500')
+      }
+    >
+      <Icon size={14} className="mt-0.5 shrink-0" />
+      <div>{children}</div>
+    </div>
+  );
+};

--- a/src/features/recover-password/ui/ForgotPasswordForm.test.tsx
+++ b/src/features/recover-password/ui/ForgotPasswordForm.test.tsx
@@ -1,0 +1,72 @@
+jest.mock('../model/recoverPasswordService', () => ({
+  requestPasswordRecovery: jest.fn(),
+}));
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { requestPasswordRecovery } from '../model/recoverPasswordService';
+import { ForgotPasswordForm } from './ForgotPasswordForm';
+
+const requestPasswordRecoveryMock = requestPasswordRecovery as jest.Mock;
+
+const renderForm = () =>
+  render(
+    <MemoryRouter>
+      <ForgotPasswordForm />
+    </MemoryRouter>,
+  );
+
+describe('ForgotPasswordForm', () => {
+  afterEach(() => {
+    requestPasswordRecoveryMock.mockReset();
+  });
+
+  it('shows backend success message after submitting email', async () => {
+    const testUser = userEvent.setup();
+    requestPasswordRecoveryMock.mockResolvedValueOnce(
+      'Se o email existir no sistema, enviamos instrucoes.',
+    );
+
+    renderForm();
+
+    await testUser.type(screen.getByLabelText(/Email/i), 'aluno@unb.br');
+    await testUser.click(screen.getByRole('button', { name: /Enviar instrucoes/i }));
+
+    expect(requestPasswordRecoveryMock).toHaveBeenCalledWith('aluno@unb.br');
+    expect(
+      await screen.findByText('Se o email existir no sistema, enviamos instrucoes.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Voltar para o login/i })).toHaveAttribute(
+      'href',
+      '/login',
+    );
+  });
+
+  it('validates required email locally', async () => {
+    const testUser = userEvent.setup();
+
+    renderForm();
+
+    await testUser.click(screen.getByRole('button', { name: /Enviar instrucoes/i }));
+
+    expect(screen.getByText('Email e obrigatorio.')).toBeInTheDocument();
+    expect(requestPasswordRecoveryMock).not.toHaveBeenCalled();
+  });
+
+  it('shows backend error message when request fails', async () => {
+    const testUser = userEvent.setup();
+    requestPasswordRecoveryMock.mockRejectedValueOnce(
+      new Error('Nao foi possivel enviar as instrucoes de recuperacao.'),
+    );
+
+    renderForm();
+
+    await testUser.type(screen.getByLabelText(/Email/i), 'aluno@unb.br');
+    await testUser.click(screen.getByRole('button', { name: /Enviar instrucoes/i }));
+
+    expect(
+      await screen.findByText('Nao foi possivel enviar as instrucoes de recuperacao.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/recover-password/ui/ForgotPasswordForm.tsx
+++ b/src/features/recover-password/ui/ForgotPasswordForm.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '../../../shared/ui/button/Button';
+import { requestPasswordRecovery } from '../model/recoverPasswordService';
+import { FeedbackMessage } from './FeedbackMessage';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const ForgotPasswordForm = () => {
+  const [email, setEmail] = useState('');
+  const [fieldError, setFieldError] = useState('');
+  const [formError, setFormError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    const trimmedEmail = email.trim();
+
+    setFieldError('');
+    setFormError('');
+    setSuccessMessage('');
+
+    if (!trimmedEmail) {
+      setFieldError('Email e obrigatorio.');
+      return;
+    }
+
+    if (!EMAIL_REGEX.test(trimmedEmail)) {
+      setFieldError('Informe um email valido.');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const message = await requestPasswordRecovery(trimmedEmail);
+      setSuccessMessage(message);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Nao foi possivel enviar as instrucoes.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form
+      aria-label="recuperar senha"
+      className="flex w-full max-w-[340px] flex-col gap-5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleSubmit();
+      }}
+    >
+      <div>
+        <h1 className="text-3xl font-black text-[#0A1128]">Recuperar Senha</h1>
+        <p className="mt-3 max-w-[280px] text-xs font-medium leading-relaxed text-[#0A1128]/70">
+          Informe seu email e enviaremos instrucoes para redefinir sua senha
+        </p>
+      </div>
+
+      {successMessage ? (
+        <FeedbackMessage variant="success">{successMessage}</FeedbackMessage>
+      ) : (
+        <>
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="email" className="text-xs font-medium text-[#0A1128]">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              aria-invalid={!!fieldError}
+              placeholder="Aluno@UnB"
+              className={
+                'h-10 w-full rounded-[7px] border bg-white px-3.5 text-sm text-[#0A1128] outline-none transition-colors placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] ' +
+                (fieldError ? 'border-red-400' : 'border-[#14D5C2]')
+              }
+              onChange={(event) => setEmail(event.target.value)}
+            />
+            {fieldError ? (
+              <span className="text-xs font-medium text-red-500">{fieldError}</span>
+            ) : null}
+          </div>
+
+          {formError ? <FeedbackMessage variant="error">{formError}</FeedbackMessage> : null}
+
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? 'Enviando...' : 'Enviar instrucoes'}
+          </Button>
+        </>
+      )}
+
+      <Link
+        to="/login"
+        className="text-center text-xs font-bold text-[#00A99D] transition-colors hover:text-[#007B6E]"
+      >
+        Voltar para o login
+      </Link>
+    </form>
+  );
+};

--- a/src/features/recover-password/ui/ForgotPasswordForm.tsx
+++ b/src/features/recover-password/ui/ForgotPasswordForm.tsx
@@ -4,8 +4,6 @@ import { Button } from '../../../shared/ui/button/Button';
 import { requestPasswordRecovery } from '../model/recoverPasswordService';
 import { FeedbackMessage } from './FeedbackMessage';
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
 export const ForgotPasswordForm = () => {
   const [email, setEmail] = useState('');
   const [fieldError, setFieldError] = useState('');
@@ -25,7 +23,7 @@ export const ForgotPasswordForm = () => {
       return;
     }
 
-    if (!EMAIL_REGEX.test(trimmedEmail)) {
+    if (!trimmedEmail.includes('@')) {
       setFieldError('Informe um email valido.');
       return;
     }

--- a/src/features/recover-password/ui/PasswordRecoveryLayout.tsx
+++ b/src/features/recover-password/ui/PasswordRecoveryLayout.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import logo from '../../../shared/assets/image/logo.png';
+
+type PasswordRecoveryLayoutProps = {
+  children: ReactNode;
+};
+
+export const PasswordRecoveryLayout = ({ children }: PasswordRecoveryLayoutProps) => (
+  <main className="relative min-h-screen w-full overflow-x-hidden bg-[#F7F7F7]">
+    <div className="absolute inset-y-0 left-0 hidden w-[57vw] bg-[#00214d] [clip-path:polygon(0_0,40%_0,100%_100%,0_100%)] md:block [@media(min-width:768px)_and_(max-width:1100px)]:w-[50vw] [@media(min-width:768px)_and_(max-height:760px)]:w-[52vw] [@media(min-width:768px)_and_(max-width:1100px)]:[clip-path:polygon(0_0,34%_0,100%_100%,0_100%)]" />
+
+    <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-5 py-8 md:flex-row md:items-center md:justify-between md:px-8 md:py-8 lg:px-16 xl:px-20">
+      <section className="mb-10 w-full md:mb-0 md:flex md:h-[calc(100vh-4rem)] md:w-[50%] md:items-center md:justify-start lg:w-[51%]">
+        <div className="flex w-full justify-center md:justify-start">
+          <img
+            src={logo}
+            alt="Logo AnatoQuizUp"
+            className="h-auto w-full max-w-[260px] md:max-w-[320px] lg:max-w-[430px] xl:max-w-[470px]"
+          />
+        </div>
+      </section>
+
+      <section className="flex w-full justify-center md:w-[50%] md:justify-end lg:w-[49%]">
+        {children}
+      </section>
+    </div>
+  </main>
+);

--- a/src/features/recover-password/ui/ResetPasswordForm.test.tsx
+++ b/src/features/recover-password/ui/ResetPasswordForm.test.tsx
@@ -1,0 +1,82 @@
+jest.mock('../model/recoverPasswordService', () => ({
+  resetPassword: jest.fn(),
+}));
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { resetPassword } from '../model/recoverPasswordService';
+import { ResetPasswordForm } from './ResetPasswordForm';
+
+const resetPasswordMock = resetPassword as jest.Mock;
+
+const renderForm = (route = '/redefinir-senha?token=token-valido') =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <ResetPasswordForm />
+    </MemoryRouter>,
+  );
+
+describe('ResetPasswordForm', () => {
+  afterEach(() => {
+    resetPasswordMock.mockReset();
+  });
+
+  it('resets password and shows backend success message', async () => {
+    const testUser = userEvent.setup();
+    resetPasswordMock.mockResolvedValueOnce('Senha redefinida com sucesso.');
+
+    renderForm();
+
+    await testUser.type(screen.getByLabelText(/^Nova senha$/i), 'senha1234');
+    await testUser.type(screen.getByLabelText(/Confirme nova senha/i), 'senha1234');
+    await testUser.click(screen.getByRole('button', { name: /Redefinir senha/i }));
+
+    expect(resetPasswordMock).toHaveBeenCalledWith('token-valido', 'senha1234');
+    expect(await screen.findByText(/Senha redefinida com sucesso./i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Ir para o login/i })).toHaveAttribute(
+      'href',
+      '/login',
+    );
+  });
+
+  it('validates password confirmation locally', async () => {
+    const testUser = userEvent.setup();
+
+    renderForm();
+
+    await testUser.type(screen.getByLabelText(/^Nova senha$/i), 'senha1234');
+    await testUser.type(screen.getByLabelText(/Confirme nova senha/i), 'senha-diferente');
+    await testUser.click(screen.getByRole('button', { name: /Redefinir senha/i }));
+
+    expect(screen.getByText('As senhas nao coincidem.')).toBeInTheDocument();
+    expect(resetPasswordMock).not.toHaveBeenCalled();
+  });
+
+  it('shows invalid link message when token is missing', async () => {
+    renderForm('/redefinir-senha');
+
+    expect(screen.getByText(/Link expirado ou invalido./i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Recuperar senha/i })).toHaveAttribute(
+      'href',
+      '/esqueci-senha',
+    );
+  });
+
+  it('shows backend error message when token is invalid', async () => {
+    const testUser = userEvent.setup();
+    resetPasswordMock.mockRejectedValueOnce(new Error('Link expirado ou invalido.'));
+
+    renderForm();
+
+    await testUser.type(screen.getByLabelText(/^Nova senha$/i), 'senha1234');
+    await testUser.type(screen.getByLabelText(/Confirme nova senha/i), 'senha1234');
+    await testUser.click(screen.getByRole('button', { name: /Redefinir senha/i }));
+
+    expect(await screen.findByText(/Link expirado ou invalido./i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Recuperar senha/i })).toHaveAttribute(
+      'href',
+      '/esqueci-senha',
+    );
+  });
+});

--- a/src/features/recover-password/ui/ResetPasswordForm.tsx
+++ b/src/features/recover-password/ui/ResetPasswordForm.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { Button } from '../../../shared/ui/button/Button';
+import { resetPassword } from '../model/recoverPasswordService';
+import { FeedbackMessage } from './FeedbackMessage';
+
+type FieldErrors = {
+  password?: string;
+  confirmPassword?: string;
+};
+
+const validate = (password: string, confirmPassword: string): FieldErrors => {
+  const errors: FieldErrors = {};
+
+  if (!password) {
+    errors.password = 'Senha e obrigatoria.';
+  } else if (password.length < 8) {
+    errors.password = 'Minimo de 8 caracteres.';
+  }
+
+  if (!confirmPassword) {
+    errors.confirmPassword = 'Confirmacao de senha e obrigatoria.';
+  } else if (password !== confirmPassword) {
+    errors.confirmPassword = 'As senhas nao coincidem.';
+  }
+
+  return errors;
+};
+
+export const ResetPasswordForm = () => {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token')?.trim() ?? '';
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState(token ? '' : 'Link expirado ou invalido.');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    setFormError('');
+    setSuccessMessage('');
+
+    if (!token) {
+      setFormError('Link expirado ou invalido.');
+      return;
+    }
+
+    const errors = validate(password, confirmPassword);
+    setFieldErrors(errors);
+
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const message = await resetPassword(token, password);
+      setSuccessMessage(message);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Link expirado ou invalido.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form
+      aria-label="redefinir senha"
+      className="flex w-full max-w-[340px] flex-col gap-5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleSubmit();
+      }}
+    >
+      <div>
+        <h1 className="text-3xl font-black text-[#0A1128]">Redefinir senha</h1>
+        <p className="mt-3 max-w-[280px] text-xs font-medium leading-relaxed text-[#0A1128]/70">
+          Escolha uma nova senha para sua conta
+        </p>
+      </div>
+
+      {successMessage ? (
+        <FeedbackMessage variant="success">
+          {successMessage}{' '}
+          <Link to="/login" className="underline underline-offset-2">
+            Ir para o login -&gt;
+          </Link>
+        </FeedbackMessage>
+      ) : formError ? (
+        <FeedbackMessage variant="error">
+          {formError}{' '}
+          <Link to="/esqueci-senha" className="underline underline-offset-2">
+            Recuperar senha -&gt;
+          </Link>
+        </FeedbackMessage>
+      ) : (
+        <>
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="password" className="text-xs font-medium text-[#0A1128]">
+              Nova senha
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              aria-invalid={!!fieldErrors.password}
+              className={
+                'h-10 w-full rounded-[7px] border bg-white px-3.5 text-sm text-[#0A1128] outline-none transition-colors placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] ' +
+                (fieldErrors.password ? 'border-red-400' : 'border-[#14D5C2]')
+              }
+              onChange={(event) => setPassword(event.target.value)}
+            />
+            <span
+              className={
+                fieldErrors.password
+                  ? 'text-xs font-medium text-red-500'
+                  : 'text-xs font-medium text-[#0A1128]/45'
+              }
+            >
+              {fieldErrors.password ?? 'Minimo de 8 caracteres.'}
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="confirmPassword" className="text-xs font-medium text-[#0A1128]">
+              Confirme nova senha
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              value={confirmPassword}
+              aria-invalid={!!fieldErrors.confirmPassword}
+              className={
+                'h-10 w-full rounded-[7px] border bg-white px-3.5 text-sm text-[#0A1128] outline-none transition-colors placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] ' +
+                (fieldErrors.confirmPassword ? 'border-red-400' : 'border-[#D7DEE8]')
+              }
+              onChange={(event) => setConfirmPassword(event.target.value)}
+            />
+            {fieldErrors.confirmPassword ? (
+              <span className="text-xs font-medium text-red-500">
+                {fieldErrors.confirmPassword}
+              </span>
+            ) : null}
+          </div>
+
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? 'Redefinindo...' : 'Redefinir senha'}
+          </Button>
+        </>
+      )}
+    </form>
+  );
+};

--- a/src/features/recover-password/ui/ResetPasswordForm.tsx
+++ b/src/features/recover-password/ui/ResetPasswordForm.tsx
@@ -9,6 +9,18 @@ type FieldErrors = {
   confirmPassword?: string;
 };
 
+type PasswordFieldsProps = {
+  confirmPassword: string;
+  fieldErrors: FieldErrors;
+  isLoading: boolean;
+  password: string;
+  onConfirmPasswordChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+};
+
+const INPUT_BASE_CLASS =
+  'h-10 w-full rounded-[7px] border bg-white px-3.5 text-sm text-[#0A1128] outline-none transition-colors placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] ';
+
 const validate = (password: string, confirmPassword: string): FieldErrors => {
   const errors: FieldErrors = {};
 
@@ -25,6 +37,78 @@ const validate = (password: string, confirmPassword: string): FieldErrors => {
   }
 
   return errors;
+};
+
+const getPasswordHintClass = (hasError: boolean) => {
+  if (hasError) {
+    return 'text-xs font-medium text-red-500';
+  }
+
+  return 'text-xs font-medium text-[#0A1128]/45';
+};
+
+const getErrorMessage = (err: unknown) => {
+  if (err instanceof Error) {
+    return err.message;
+  }
+
+  return 'Link expirado ou invalido.';
+};
+
+const PasswordFields = ({
+  confirmPassword,
+  fieldErrors,
+  isLoading,
+  password,
+  onConfirmPasswordChange,
+  onPasswordChange,
+}: PasswordFieldsProps) => {
+  const passwordHasError = Boolean(fieldErrors.password);
+  const confirmPasswordHasError = Boolean(fieldErrors.confirmPassword);
+
+  return (
+    <>
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="password" className="text-xs font-medium text-[#0A1128]">
+          Nova senha
+        </label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          aria-invalid={passwordHasError}
+          className={`${INPUT_BASE_CLASS}${passwordHasError ? 'border-red-400' : 'border-[#14D5C2]'}`}
+          onChange={(event) => onPasswordChange(event.target.value)}
+        />
+        <span className={getPasswordHintClass(passwordHasError)}>
+          {fieldErrors.password ?? 'Minimo de 8 caracteres.'}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="confirmPassword" className="text-xs font-medium text-[#0A1128]">
+          Confirme nova senha
+        </label>
+        <input
+          id="confirmPassword"
+          type="password"
+          value={confirmPassword}
+          aria-invalid={confirmPasswordHasError}
+          className={`${INPUT_BASE_CLASS}${confirmPasswordHasError ? 'border-red-400' : 'border-[#D7DEE8]'}`}
+          onChange={(event) => onConfirmPasswordChange(event.target.value)}
+        />
+        {fieldErrors.confirmPassword ? (
+          <span className="text-xs font-medium text-red-500">
+            {fieldErrors.confirmPassword}
+          </span>
+        ) : null}
+      </div>
+
+      <Button type="submit" disabled={isLoading}>
+        {isLoading ? 'Redefinindo...' : 'Redefinir senha'}
+      </Button>
+    </>
+  );
 };
 
 export const ResetPasswordForm = () => {
@@ -59,11 +143,16 @@ export const ResetPasswordForm = () => {
       const message = await resetPassword(token, password);
       setSuccessMessage(message);
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : 'Link expirado ou invalido.');
+      setFormError(getErrorMessage(err));
     } finally {
       setIsLoading(false);
     }
   };
+
+  const feedback = successMessage || formError;
+  const feedbackVariant = successMessage ? 'success' : 'error';
+  const feedbackLink = successMessage ? '/login' : '/esqueci-senha';
+  const feedbackLinkLabel = successMessage ? 'Ir para o login ->' : 'Recuperar senha ->';
 
   return (
     <form
@@ -81,74 +170,22 @@ export const ResetPasswordForm = () => {
         </p>
       </div>
 
-      {successMessage ? (
-        <FeedbackMessage variant="success">
-          {successMessage}{' '}
-          <Link to="/login" className="underline underline-offset-2">
-            Ir para o login -&gt;
-          </Link>
-        </FeedbackMessage>
-      ) : formError ? (
-        <FeedbackMessage variant="error">
-          {formError}{' '}
-          <Link to="/esqueci-senha" className="underline underline-offset-2">
-            Recuperar senha -&gt;
+      {feedback ? (
+        <FeedbackMessage variant={feedbackVariant}>
+          {feedback}{' '}
+          <Link to={feedbackLink} className="underline underline-offset-2">
+            {feedbackLinkLabel}
           </Link>
         </FeedbackMessage>
       ) : (
-        <>
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="password" className="text-xs font-medium text-[#0A1128]">
-              Nova senha
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              aria-invalid={!!fieldErrors.password}
-              className={
-                'h-10 w-full rounded-[7px] border bg-white px-3.5 text-sm text-[#0A1128] outline-none transition-colors placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] ' +
-                (fieldErrors.password ? 'border-red-400' : 'border-[#14D5C2]')
-              }
-              onChange={(event) => setPassword(event.target.value)}
-            />
-            <span
-              className={
-                fieldErrors.password
-                  ? 'text-xs font-medium text-red-500'
-                  : 'text-xs font-medium text-[#0A1128]/45'
-              }
-            >
-              {fieldErrors.password ?? 'Minimo de 8 caracteres.'}
-            </span>
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="confirmPassword" className="text-xs font-medium text-[#0A1128]">
-              Confirme nova senha
-            </label>
-            <input
-              id="confirmPassword"
-              type="password"
-              value={confirmPassword}
-              aria-invalid={!!fieldErrors.confirmPassword}
-              className={
-                'h-10 w-full rounded-[7px] border bg-white px-3.5 text-sm text-[#0A1128] outline-none transition-colors placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] ' +
-                (fieldErrors.confirmPassword ? 'border-red-400' : 'border-[#D7DEE8]')
-              }
-              onChange={(event) => setConfirmPassword(event.target.value)}
-            />
-            {fieldErrors.confirmPassword ? (
-              <span className="text-xs font-medium text-red-500">
-                {fieldErrors.confirmPassword}
-              </span>
-            ) : null}
-          </div>
-
-          <Button type="submit" disabled={isLoading}>
-            {isLoading ? 'Redefinindo...' : 'Redefinir senha'}
-          </Button>
-        </>
+        <PasswordFields
+          confirmPassword={confirmPassword}
+          fieldErrors={fieldErrors}
+          isLoading={isLoading}
+          password={password}
+          onConfirmPasswordChange={setConfirmPassword}
+          onPasswordChange={setPassword}
+        />
       )}
     </form>
   );

--- a/src/pages/forgot-password/index.ts
+++ b/src/pages/forgot-password/index.ts
@@ -1,0 +1,1 @@
+export { ForgotPasswordPage } from './ui/ForgotPasswordPage';

--- a/src/pages/forgot-password/ui/ForgotPasswordPage.test.tsx
+++ b/src/pages/forgot-password/ui/ForgotPasswordPage.test.tsx
@@ -1,0 +1,22 @@
+jest.mock('../../../features/recover-password', () => ({
+  ForgotPasswordForm: () => <form aria-label="forgot password form" />,
+  PasswordRecoveryLayout: ({ children }: { children: ReactNode }) => (
+    <main>
+      <span>Recovery layout</span>
+      {children}
+    </main>
+  ),
+}));
+
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { ForgotPasswordPage } from './ForgotPasswordPage';
+
+describe('ForgotPasswordPage', () => {
+  it('renders recovery layout and forgot password form', () => {
+    render(<ForgotPasswordPage />);
+
+    expect(screen.getByText('Recovery layout')).toBeInTheDocument();
+    expect(screen.getByRole('form', { name: /forgot password form/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/forgot-password/ui/ForgotPasswordPage.tsx
+++ b/src/pages/forgot-password/ui/ForgotPasswordPage.tsx
@@ -1,0 +1,10 @@
+import {
+  ForgotPasswordForm,
+  PasswordRecoveryLayout,
+} from '../../../features/recover-password';
+
+export const ForgotPasswordPage = () => (
+  <PasswordRecoveryLayout>
+    <ForgotPasswordForm />
+  </PasswordRecoveryLayout>
+);

--- a/src/pages/reset-password/index.ts
+++ b/src/pages/reset-password/index.ts
@@ -1,0 +1,1 @@
+export { ResetPasswordPage } from './ui/ResetPasswordPage';

--- a/src/pages/reset-password/ui/ResetPasswordPage.test.tsx
+++ b/src/pages/reset-password/ui/ResetPasswordPage.test.tsx
@@ -1,0 +1,22 @@
+jest.mock('../../../features/recover-password', () => ({
+  PasswordRecoveryLayout: ({ children }: { children: ReactNode }) => (
+    <main>
+      <span>Recovery layout</span>
+      {children}
+    </main>
+  ),
+  ResetPasswordForm: () => <form aria-label="reset password form" />,
+}));
+
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { ResetPasswordPage } from './ResetPasswordPage';
+
+describe('ResetPasswordPage', () => {
+  it('renders recovery layout and reset password form', () => {
+    render(<ResetPasswordPage />);
+
+    expect(screen.getByText('Recovery layout')).toBeInTheDocument();
+    expect(screen.getByRole('form', { name: /reset password form/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/reset-password/ui/ResetPasswordPage.tsx
+++ b/src/pages/reset-password/ui/ResetPasswordPage.tsx
@@ -1,0 +1,10 @@
+import {
+  PasswordRecoveryLayout,
+  ResetPasswordForm,
+} from '../../../features/recover-password';
+
+export const ResetPasswordPage = () => (
+  <PasswordRecoveryLayout>
+    <ResetPasswordForm />
+  </PasswordRecoveryLayout>
+);


### PR DESCRIPTION
## Descrição

Implementa o fluxo de recuperação de senha no frontend, com páginas para solicitar instruções por email e redefinir a senha usando o token recebido.

## Rastreabilidade

Issue(s) Relacionada(s):

Closes #14 

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Evidências (se aplicável)

- Página `/esqueci-senha` com campo de email e envio de instruções.
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/d9872f64-ade9-4a8f-b7ea-39d47d17751d" />

- Página `/redefinir-senha?token=...` com campos de nova senha e confirmação.
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/e23b3adc-e30b-48f7-90c8-491f7b786cb3" />

- Mensagens de sucesso/erro exibidas conforme retorno da API.
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/1ccaac3b-1fa1-442c-accb-8f401df7c3a6" />
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/fe6c20cd-2349-4b3b-b56c-1460a1bf9425" />


## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

As mensagens exibidas usam diretamente o retorno do backend. Após redefinir a senha com sucesso, o usuário permanece na tela com link manual para voltar ao login, sem redirecionamento automático.