### PR TITLE
Feature/cadastro professor

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -31,6 +31,10 @@ jest.mock('../pages/register/index', () => ({
   RegisterPage: () => <main>Register route</main>,
 }));
 
+jest.mock('../pages/professor-register', () => ({
+  ProfessorRegisterPage: () => <main>Professor register route</main>,
+}));
+
 jest.mock('../pages/forgot-password', () => ({
   ForgotPasswordPage: () => <main>Forgot password route</main>,
 }));
@@ -59,6 +63,12 @@ describe('App', () => {
     renderAppAt('/cadastro');
 
     expect(screen.getByText('Register route')).toBeInTheDocument();
+  });
+
+  it('renders the professor register route', () => {
+    renderAppAt('/professor/cadastro');
+
+    expect(screen.getByText('Professor register route')).toBeInTheDocument();
   });
 
   it('renders the forgot password route', () => {

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -3,6 +3,7 @@ import { LoginPage } from "../pages/login/index";
 import { HomePage } from "../pages/home/index";
 import { HomeAlunoPage } from "../pages/homeAluno/index";
 import { RegisterPage } from "../pages/register/index";
+import { ProfessorRegisterPage } from "../pages/professor-register";
 import { ForgotPasswordPage } from "../pages/forgot-password";
 import { ResetPasswordPage } from "../pages/reset-password";
 import { AuthenticatedLayout } from "./layouts/AuthenticatedLayout";
@@ -15,6 +16,7 @@ export const AppRouter = () => {
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/cadastro" element={<RegisterPage />} />
+      <Route path="/professor/cadastro" element={<ProfessorRegisterPage />} />
       <Route path="/esqueci-senha" element={<ForgotPasswordPage />} />
       <Route path="/redefinir-senha" element={<ResetPasswordPage />} />
     

--- a/src/features/register-professor/index.ts
+++ b/src/features/register-professor/index.ts
@@ -1,0 +1,1 @@
+export { RegisterProfessorForm } from './ui/RegisterProfessorForm';

--- a/src/features/register-professor/model/mockRegisterProfessorService.test.ts
+++ b/src/features/register-professor/model/mockRegisterProfessorService.test.ts
@@ -1,0 +1,19 @@
+import { registerProfessorMock } from './mockRegisterProfessorService';
+import { PROFESSOR_INSTITUTION, type RegisterProfessorFormValues } from './types';
+
+const formValues: RegisterProfessorFormValues = {
+  fullName: 'Hilmer Rodrigues Neri',
+  email: 'hilmer@unb.br',
+  password: 'senhaValida123',
+  confirmPassword: 'senhaValida123',
+  institution: PROFESSOR_INSTITUTION,
+  siape: '1234567',
+  department: 'Anatomia',
+  course: 'Medicina',
+};
+
+describe('registerProfessorMock', () => {
+  it('resolve cadastro simulado do professor', async () => {
+    await expect(registerProfessorMock(formValues)).resolves.toBeUndefined();
+  });
+});

--- a/src/features/register-professor/model/mockRegisterProfessorService.ts
+++ b/src/features/register-professor/model/mockRegisterProfessorService.ts
@@ -1,0 +1,7 @@
+import type { RegisterProfessorFormValues } from './types';
+
+export const registerProfessorMock = async (
+  values: RegisterProfessorFormValues,
+): Promise<void> => {
+  void values;
+};

--- a/src/features/register-professor/model/mockRegisterProfessorService.ts
+++ b/src/features/register-professor/model/mockRegisterProfessorService.ts
@@ -1,7 +1,5 @@
 import type { RegisterProfessorFormValues } from './types';
 
-export const registerProfessorMock = async (
+export const registerProfessorMock = (
   values: RegisterProfessorFormValues,
-): Promise<void> => {
-  void values;
-};
+): Promise<void> => Promise.resolve(values).then(() => undefined);

--- a/src/features/register-professor/model/registerProfessorService.test.ts
+++ b/src/features/register-professor/model/registerProfessorService.test.ts
@@ -1,0 +1,134 @@
+/// <reference types="jest" />
+/// <reference types="node" />
+
+const postMock = jest.fn();
+const registerProfessorMock = jest.fn();
+
+const loadService = async (useMocks: boolean) => {
+  jest.resetModules();
+  postMock.mockReset();
+  registerProfessorMock.mockReset();
+
+  jest.doMock('../../../shared/api/httpClient', () => ({
+    httpClient: {
+      post: postMock,
+    },
+  }));
+
+  jest.doMock('../../../shared/config/env', () => ({
+    USE_MOCKS: useMocks,
+  }));
+
+  jest.doMock('./mockRegisterProfessorService', () => ({
+    registerProfessorMock,
+  }));
+
+  return import('./registerProfessorService');
+};
+
+import {
+  PROFESSOR_INSTITUTION,
+  type RegisterProfessorFormValues,
+} from './types';
+
+const formValues: RegisterProfessorFormValues = {
+  fullName: ' Hilmer Rodrigues Neri ',
+  email: ' HILMER@UNB.BR ',
+  password: 'password123',
+  confirmPassword: 'password123',
+  institution: PROFESSOR_INSTITUTION,
+  siape: '1234567',
+  department: ' Anatomia ',
+  course: ' Medicina ',
+};
+
+describe('registerProfessor', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the mock register service without calling the API when mocks are enabled', async () => {
+    const { registerProfessor } = await loadService(true);
+    registerProfessorMock.mockResolvedValueOnce(undefined);
+
+    await registerProfessor(formValues);
+
+    expect(registerProfessorMock).toHaveBeenCalledWith(formValues);
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('envia payload no formato esperado pela API com textos trimados', async () => {
+    const { registerProfessor } = await loadService(false);
+    postMock.mockResolvedValueOnce({ data: { mensagem: 'ok' } });
+
+    await registerProfessor(formValues);
+
+    expect(postMock).toHaveBeenCalledWith('/auth/professores/register', {
+      nome: 'Hilmer Rodrigues Neri',
+      email: 'hilmer@unb.br',
+      siape: '1234567',
+      instituicao: PROFESSOR_INSTITUTION,
+      departamento: 'Anatomia',
+      curso: 'Medicina',
+      senha: 'password123',
+      confirmacaoSenha: 'password123',
+    });
+  });
+
+  it('retorna erro inline de email quando API informa email em uso', async () => {
+    const { registerProfessor } = await loadService(false);
+    postMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: {
+          erro: {
+            mensagem: 'Email ja cadastrado.',
+            detalhes: { email: 'hilmer@unb.br' },
+          },
+        },
+      },
+    });
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      expect.objectContaining({
+        message: 'Email ja cadastrado.',
+        fieldErrors: { email: 'Email ja cadastrado.' },
+      }),
+    );
+  });
+
+  it('retorna erro inline de SIAPE quando API informa SIAPE em uso', async () => {
+    const { registerProfessor } = await loadService(false);
+    postMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: {
+          erro: {
+            mensagem: 'SIAPE ja cadastrado.',
+            detalhes: { siape: '1234567' },
+          },
+        },
+      },
+    });
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      expect.objectContaining({
+        message: 'SIAPE ja cadastrado.',
+        fieldErrors: { siape: 'SIAPE ja cadastrado.' },
+      }),
+    );
+  });
+
+  it('retorna mensagem amigavel quando servidor esta indisponivel', async () => {
+    const { registerProfessor, RegisterProfessorError } = await loadService(false);
+    postMock.mockRejectedValueOnce({
+      isAxiosError: true,
+    });
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      new RegisterProfessorError('Não foi possível conectar ao servidor. Tente novamente.'),
+    );
+  });
+});

--- a/src/features/register-professor/model/registerProfessorService.test.ts
+++ b/src/features/register-professor/model/registerProfessorService.test.ts
@@ -63,11 +63,11 @@ describe('registerProfessor', () => {
 
     await registerProfessor(formValues);
 
-    expect(postMock).toHaveBeenCalledWith('/auth/professores/register', {
+    expect(postMock).toHaveBeenCalledWith('/autenticacao/cadastro/professor', {
       nome: 'Hilmer Rodrigues Neri',
       email: 'hilmer@unb.br',
       siape: '1234567',
-      instituicao: PROFESSOR_INSTITUTION,
+      instituicao: 'UnB',
       departamento: 'Anatomia',
       curso: 'Medicina',
       senha: 'password123',

--- a/src/features/register-professor/model/registerProfessorService.test.ts
+++ b/src/features/register-professor/model/registerProfessorService.test.ts
@@ -26,21 +26,27 @@ const loadService = async (useMocks: boolean) => {
   return import('./registerProfessorService');
 };
 
-import {
-  PROFESSOR_INSTITUTION,
-  type RegisterProfessorFormValues,
-} from './types';
+import { PROFESSOR_INSTITUTION, type RegisterProfessorFormValues } from './types';
 
+const VALID_PASSWORD = 'senhaValida123';
 const formValues: RegisterProfessorFormValues = {
   fullName: ' Hilmer Rodrigues Neri ',
   email: ' HILMER@UNB.BR ',
-  password: 'password123',
-  confirmPassword: 'password123',
+  password: VALID_PASSWORD,
+  confirmPassword: VALID_PASSWORD,
   institution: PROFESSOR_INSTITUTION,
   siape: '1234567',
   department: ' Anatomia ',
   course: ' Medicina ',
 };
+
+const axiosError = (data?: unknown) => ({
+  isAxiosError: true,
+  response: {
+    status: 400,
+    data,
+  },
+});
 
 describe('registerProfessor', () => {
   afterEach(() => {
@@ -70,25 +76,21 @@ describe('registerProfessor', () => {
       instituicao: 'UnB',
       departamento: 'Anatomia',
       curso: 'Medicina',
-      senha: 'password123',
-      confirmacaoSenha: 'password123',
+      senha: VALID_PASSWORD,
+      confirmacaoSenha: VALID_PASSWORD,
     });
   });
 
   it('retorna erro inline de email quando API informa email em uso', async () => {
     const { registerProfessor } = await loadService(false);
-    postMock.mockRejectedValueOnce({
-      isAxiosError: true,
-      response: {
-        status: 409,
-        data: {
-          erro: {
-            mensagem: 'Email ja cadastrado.',
-            detalhes: { email: 'hilmer@unb.br' },
-          },
+    postMock.mockRejectedValueOnce(
+      axiosError({
+        erro: {
+          mensagem: 'Email ja cadastrado.',
+          detalhes: { email: 'hilmer@unb.br' },
         },
-      },
-    });
+      }),
+    );
 
     await expect(registerProfessor(formValues)).rejects.toEqual(
       expect.objectContaining({
@@ -98,25 +100,102 @@ describe('registerProfessor', () => {
     );
   });
 
-  it('retorna erro inline de SIAPE quando API informa SIAPE em uso', async () => {
+  it('retorna erro inline de email quando detalhes vem como lista', async () => {
     const { registerProfessor } = await loadService(false);
-    postMock.mockRejectedValueOnce({
-      isAxiosError: true,
-      response: {
-        status: 409,
-        data: {
-          erro: {
-            mensagem: 'SIAPE ja cadastrado.',
-            detalhes: { siape: '1234567' },
+    postMock.mockRejectedValueOnce(
+      axiosError({
+        erro: {
+          mensagem: 'Validacao invalida.',
+          detalhes: [{ campo: 'email', mensagem: 'Email institucional UnB obrigatório.' }],
+        },
+      }),
+    );
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      expect.objectContaining({
+        message: 'Email institucional UnB obrigatório.',
+        fieldErrors: { email: 'Email institucional UnB obrigatório.' },
+      }),
+    );
+  });
+
+  it('retorna erro inline de email quando detalhes vem em estrutura de validacao aninhada', async () => {
+    const { registerProfessor } = await loadService(false);
+    postMock.mockRejectedValueOnce(
+      axiosError({
+        erro: {
+          detalhes: {
+            email: {
+              errors: ['Email institucional UnB obrigatório.'],
+            },
           },
         },
-      },
-    });
+      }),
+    );
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      expect.objectContaining({
+        message: 'Email institucional UnB obrigatório.',
+        fieldErrors: { email: 'Email institucional UnB obrigatório.' },
+      }),
+    );
+  });
+
+  it('retorna erro inline de SIAPE quando API informa SIAPE em uso', async () => {
+    const { registerProfessor } = await loadService(false);
+    postMock.mockRejectedValueOnce(
+      axiosError({
+        erro: {
+          mensagem: 'SIAPE ja cadastrado.',
+          detalhes: { siape: '1234567' },
+        },
+      }),
+    );
 
     await expect(registerProfessor(formValues)).rejects.toEqual(
       expect.objectContaining({
         message: 'SIAPE ja cadastrado.',
         fieldErrors: { siape: 'SIAPE ja cadastrado.' },
+      }),
+    );
+  });
+
+  it('retorna erro inline de SIAPE quando validacao vem em properties', async () => {
+    const { registerProfessor } = await loadService(false);
+    postMock.mockRejectedValueOnce(
+      axiosError({
+        erro: {
+          detalhes: {
+            properties: {
+              siape: {
+                errors: ['SIAPE inválido.'],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      expect.objectContaining({
+        message: 'SIAPE inválido.',
+        fieldErrors: { siape: 'SIAPE inválido.' },
+      }),
+    );
+  });
+
+  it('identifica campo duplicado pela mensagem geral do backend', async () => {
+    const { registerProfessor } = await loadService(false);
+    postMock.mockRejectedValueOnce(
+      axiosError({
+        mensagem: 'Email ja cadastrado.',
+      }),
+    );
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      expect.objectContaining({
+        message: 'Email ja cadastrado.',
+        fieldErrors: { email: 'Email ja cadastrado.' },
       }),
     );
   });
@@ -129,6 +208,33 @@ describe('registerProfessor', () => {
 
     await expect(registerProfessor(formValues)).rejects.toEqual(
       new RegisterProfessorError('Não foi possível conectar ao servidor. Tente novamente.'),
+    );
+  });
+
+  it('retorna mensagem amigavel quando erro nao vem do axios', async () => {
+    const { registerProfessor, RegisterProfessorError } = await loadService(false);
+    postMock.mockRejectedValueOnce(new Error('falha local'));
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      new RegisterProfessorError('Não foi possível concluir o cadastro. Tente novamente.'),
+    );
+  });
+
+  it('repassa mensagem geral do backend quando nao ha erro de campo', async () => {
+    const { registerProfessor, RegisterProfessorError } = await loadService(false);
+    postMock.mockRejectedValueOnce(axiosError({ message: 'Falha de cadastro.' }));
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      new RegisterProfessorError('Falha de cadastro.'),
+    );
+  });
+
+  it('usa mensagem generica quando backend nao retorna mensagem', async () => {
+    const { registerProfessor, RegisterProfessorError } = await loadService(false);
+    postMock.mockRejectedValueOnce(axiosError({}));
+
+    await expect(registerProfessor(formValues)).rejects.toEqual(
+      new RegisterProfessorError('Não foi possível concluir o cadastro. Tente novamente.'),
     );
   });
 });

--- a/src/features/register-professor/model/registerProfessorService.ts
+++ b/src/features/register-professor/model/registerProfessorService.ts
@@ -1,0 +1,137 @@
+import axios from 'axios';
+import { httpClient } from '../../../shared/api/httpClient';
+import { USE_MOCKS } from '../../../shared/config/env';
+import { registerProfessorMock } from './mockRegisterProfessorService';
+import type {
+  RegisterProfessorApiPayload,
+  RegisterProfessorField,
+  RegisterProfessorFieldErrors,
+  RegisterProfessorFormValues,
+} from './types';
+
+export class RegisterProfessorError extends Error {
+  public readonly fieldErrors?: RegisterProfessorFieldErrors;
+
+  constructor(message: string, fieldErrors?: RegisterProfessorFieldErrors) {
+    super(message);
+    this.name = 'RegisterProfessorError';
+    this.fieldErrors = fieldErrors;
+  }
+}
+
+type ApiErroDetalhe = {
+  campo?: string;
+  mensagem?: string;
+};
+
+type ApiErroResponse = {
+  mensagem?: string;
+  erro?: {
+    mensagem?: string;
+    detalhes?: ApiErroDetalhe[] | Record<string, unknown>;
+  };
+  message?: string;
+};
+
+const mapValuesToPayload = (
+  values: RegisterProfessorFormValues,
+): RegisterProfessorApiPayload => ({
+  nome: values.fullName.trim(),
+  email: values.email.trim().toLowerCase(),
+  siape: values.siape.trim(),
+  instituicao: values.institution,
+  departamento: values.department.trim(),
+  curso: values.course.trim(),
+  senha: values.password,
+  confirmacaoSenha: values.confirmPassword,
+});
+
+const getBackendMessage = (response: ApiErroResponse): string =>
+  response.erro?.mensagem ?? response.mensagem ?? response.message ?? '';
+
+const getNestedValidationMessage = (value: unknown): string | null => {
+  if (!value || typeof value !== 'object') return null;
+
+  const errors = (value as { errors?: unknown }).errors;
+  if (Array.isArray(errors) && typeof errors[0] === 'string') {
+    return errors[0];
+  }
+
+  return null;
+};
+
+const extractFieldError = (
+  response: ApiErroResponse,
+  field: Extract<RegisterProfessorField, 'email' | 'siape'>,
+): string | null => {
+  const detalhes = response.erro?.detalhes;
+  const backendMessage = getBackendMessage(response);
+
+  if (Array.isArray(detalhes)) {
+    const fieldDetail = detalhes.find((detalhe) => detalhe.campo === field);
+    if (fieldDetail) return fieldDetail.mensagem ?? backendMessage;
+  }
+
+  if (detalhes && typeof detalhes === 'object') {
+    const fieldValue = (detalhes as Record<string, unknown>)[field];
+    const nestedMessage = getNestedValidationMessage(fieldValue);
+    if (nestedMessage) return nestedMessage;
+
+    if (typeof fieldValue === 'string') {
+      return /cadastrado|uso|existente|ja|já/i.test(backendMessage)
+        ? backendMessage
+        : fieldValue;
+    }
+
+    const properties = (detalhes as { properties?: Record<string, unknown> }).properties;
+    const propertyMessage = properties ? getNestedValidationMessage(properties[field]) : null;
+    if (propertyMessage) return propertyMessage;
+  }
+
+  if (
+    new RegExp(field, 'i').test(backendMessage) &&
+    /cadastrado|uso|existente|ja|já/i.test(backendMessage)
+  ) {
+    return backendMessage;
+  }
+
+  return null;
+};
+
+export const registerProfessor = async (
+  values: RegisterProfessorFormValues,
+): Promise<void> => {
+  if (USE_MOCKS) {
+    await registerProfessorMock(values);
+    return;
+  }
+
+  try {
+    await httpClient.post('/auth/professores/register', mapValuesToPayload(values));
+  } catch (error) {
+    if (!axios.isAxiosError(error)) {
+      throw new RegisterProfessorError('Não foi possível concluir o cadastro. Tente novamente.');
+    }
+
+    if (!error.response) {
+      throw new RegisterProfessorError('Não foi possível conectar ao servidor. Tente novamente.');
+    }
+
+    const responseData = (error.response.data ?? {}) as ApiErroResponse;
+    const backendMessage = getBackendMessage(responseData);
+    const emailError = extractFieldError(responseData, 'email');
+    const siapeError = extractFieldError(responseData, 'siape');
+
+    if (emailError) {
+      throw new RegisterProfessorError(emailError, { email: emailError });
+    }
+
+    if (siapeError) {
+      throw new RegisterProfessorError(siapeError, { siape: siapeError });
+    }
+
+    throw new RegisterProfessorError(
+      backendMessage || 'Não foi possível concluir o cadastro. Tente novamente.',
+    );
+  }
+};

--- a/src/features/register-professor/model/registerProfessorService.ts
+++ b/src/features/register-professor/model/registerProfessorService.ts
@@ -33,6 +33,17 @@ type ApiErroResponse = {
   message?: string;
 };
 
+type ProfessorUniqueField = Extract<RegisterProfessorField, 'email' | 'siape'>;
+
+const PROFESSOR_REGISTER_ENDPOINT = '/autenticacao/cadastro/professor';
+const GENERIC_REGISTER_ERROR = 'Não foi possível concluir o cadastro. Tente novamente.';
+const SERVER_UNAVAILABLE_ERROR = 'Não foi possível conectar ao servidor. Tente novamente.';
+const DUPLICATED_FIELD_MESSAGE_REGEX = /cadastrado|uso|existente|ja|já/i;
+const FIELD_MESSAGE_REGEX: Record<ProfessorUniqueField, RegExp> = {
+  email: /email/i,
+  siape: /siape/i,
+};
+
 const mapValuesToPayload = (
   values: RegisterProfessorFormValues,
 ): RegisterProfessorApiPayload => ({
@@ -60,42 +71,64 @@ const getNestedValidationMessage = (value: unknown): string | null => {
   return null;
 };
 
+const extractFieldErrorFromList = (
+  detalhes: ApiErroDetalhe[] | undefined,
+  field: ProfessorUniqueField,
+  backendMessage: string,
+): string | null => {
+  const fieldDetail = detalhes?.find((detalhe) => detalhe.campo === field);
+  return fieldDetail ? fieldDetail.mensagem ?? backendMessage : null;
+};
+
+const extractFieldErrorFromObject = (
+  detalhes: Record<string, unknown>,
+  field: ProfessorUniqueField,
+  backendMessage: string,
+): string | null => {
+  const fieldValue = detalhes[field];
+  const nestedMessage = getNestedValidationMessage(fieldValue);
+  if (nestedMessage) return nestedMessage;
+
+  if (typeof fieldValue === 'string') {
+    return DUPLICATED_FIELD_MESSAGE_REGEX.test(backendMessage)
+      ? backendMessage
+      : fieldValue;
+  }
+
+  const properties = (detalhes as { properties?: Record<string, unknown> }).properties;
+  return properties ? getNestedValidationMessage(properties[field]) : null;
+};
+
+const extractFieldErrorFromMessage = (
+  backendMessage: string,
+  field: ProfessorUniqueField,
+): string | null =>
+  FIELD_MESSAGE_REGEX[field].test(backendMessage) &&
+  DUPLICATED_FIELD_MESSAGE_REGEX.test(backendMessage)
+    ? backendMessage
+    : null;
+
 const extractFieldError = (
   response: ApiErroResponse,
-  field: Extract<RegisterProfessorField, 'email' | 'siape'>,
+  field: ProfessorUniqueField,
 ): string | null => {
   const detalhes = response.erro?.detalhes;
   const backendMessage = getBackendMessage(response);
 
   if (Array.isArray(detalhes)) {
-    const fieldDetail = detalhes.find((detalhe) => detalhe.campo === field);
-    if (fieldDetail) return fieldDetail.mensagem ?? backendMessage;
+    return extractFieldErrorFromList(detalhes, field, backendMessage);
   }
 
   if (detalhes && typeof detalhes === 'object') {
-    const fieldValue = (detalhes as Record<string, unknown>)[field];
-    const nestedMessage = getNestedValidationMessage(fieldValue);
-    if (nestedMessage) return nestedMessage;
-
-    if (typeof fieldValue === 'string') {
-      return /cadastrado|uso|existente|ja|já/i.test(backendMessage)
-        ? backendMessage
-        : fieldValue;
-    }
-
-    const properties = (detalhes as { properties?: Record<string, unknown> }).properties;
-    const propertyMessage = properties ? getNestedValidationMessage(properties[field]) : null;
-    if (propertyMessage) return propertyMessage;
+    const objectMessage = extractFieldErrorFromObject(
+      detalhes as Record<string, unknown>,
+      field,
+      backendMessage,
+    );
+    if (objectMessage) return objectMessage;
   }
 
-  if (
-    new RegExp(field, 'i').test(backendMessage) &&
-    /cadastrado|uso|existente|ja|já/i.test(backendMessage)
-  ) {
-    return backendMessage;
-  }
-
-  return null;
+  return extractFieldErrorFromMessage(backendMessage, field);
 };
 
 export const registerProfessor = async (
@@ -107,14 +140,14 @@ export const registerProfessor = async (
   }
 
   try {
-    await httpClient.post('/autenticacao/cadastro/professor', mapValuesToPayload(values));
+    await httpClient.post(PROFESSOR_REGISTER_ENDPOINT, mapValuesToPayload(values));
   } catch (error) {
     if (!axios.isAxiosError(error)) {
-      throw new RegisterProfessorError('Não foi possível concluir o cadastro. Tente novamente.');
+      throw new RegisterProfessorError(GENERIC_REGISTER_ERROR);
     }
 
     if (!error.response) {
-      throw new RegisterProfessorError('Não foi possível conectar ao servidor. Tente novamente.');
+      throw new RegisterProfessorError(SERVER_UNAVAILABLE_ERROR);
     }
 
     const responseData = (error.response.data ?? {}) as ApiErroResponse;
@@ -130,8 +163,6 @@ export const registerProfessor = async (
       throw new RegisterProfessorError(siapeError, { siape: siapeError });
     }
 
-    throw new RegisterProfessorError(
-      backendMessage || 'Não foi possível concluir o cadastro. Tente novamente.',
-    );
+    throw new RegisterProfessorError(backendMessage || GENERIC_REGISTER_ERROR);
   }
 };

--- a/src/features/register-professor/model/registerProfessorService.ts
+++ b/src/features/register-professor/model/registerProfessorService.ts
@@ -39,7 +39,7 @@ const mapValuesToPayload = (
   nome: values.fullName.trim(),
   email: values.email.trim().toLowerCase(),
   siape: values.siape.trim(),
-  instituicao: values.institution,
+  instituicao: 'UnB',
   departamento: values.department.trim(),
   curso: values.course.trim(),
   senha: values.password,
@@ -107,7 +107,7 @@ export const registerProfessor = async (
   }
 
   try {
-    await httpClient.post('/auth/professores/register', mapValuesToPayload(values));
+    await httpClient.post('/autenticacao/cadastro/professor', mapValuesToPayload(values));
   } catch (error) {
     if (!axios.isAxiosError(error)) {
       throw new RegisterProfessorError('Não foi possível concluir o cadastro. Tente novamente.');

--- a/src/features/register-professor/model/types.ts
+++ b/src/features/register-professor/model/types.ts
@@ -1,0 +1,35 @@
+export const PROFESSOR_INSTITUTION = 'Universidade de Brasília — UnB';
+
+export type RegisterProfessorFormValues = {
+  fullName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  institution: string;
+  siape: string;
+  department: string;
+  course: string;
+};
+
+export type RegisterProfessorField =
+  | 'fullName'
+  | 'email'
+  | 'password'
+  | 'confirmPassword'
+  | 'institution'
+  | 'siape'
+  | 'department'
+  | 'course';
+
+export type RegisterProfessorFieldErrors = Partial<Record<RegisterProfessorField, string>>;
+
+export type RegisterProfessorApiPayload = {
+  nome: string;
+  email: string;
+  siape: string;
+  instituicao: string;
+  departamento: string;
+  curso: string;
+  senha: string;
+  confirmacaoSenha: string;
+};

--- a/src/features/register-professor/ui/RegisterProfessorForm.test.tsx
+++ b/src/features/register-professor/ui/RegisterProfessorForm.test.tsx
@@ -1,0 +1,195 @@
+jest.mock('../model/registerProfessorService', () => {
+  class RegisterProfessorError extends Error {
+    fieldErrors?: Record<string, string>;
+
+    constructor(message: string, fieldErrors?: Record<string, string>) {
+      super(message);
+      this.name = 'RegisterProfessorError';
+      this.fieldErrors = fieldErrors;
+    }
+  }
+
+  return {
+    registerProfessor: jest.fn(),
+    RegisterProfessorError,
+  };
+});
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { registerProfessor, RegisterProfessorError } from '../model/registerProfessorService';
+import { PROFESSOR_INSTITUTION } from '../model/types';
+import { RegisterProfessorForm } from './RegisterProfessorForm';
+
+const registerProfessorMock = registerProfessor as jest.Mock;
+
+const renderForm = () =>
+  render(
+    <MemoryRouter initialEntries={['/professor/cadastro']}>
+      <RegisterProfessorForm />
+    </MemoryRouter>,
+  );
+
+const preencherPasso1 = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(screen.getByLabelText(/Nome completo/i), 'Hilmer Rodrigues Neri');
+  await user.type(screen.getByLabelText(/Email institucional/i), 'hilmer@unb.br');
+  await user.type(screen.getByLabelText(/^Senha/i), 'password123');
+  await user.type(screen.getByLabelText(/Confirmação de senha/i), 'password123');
+  await user.click(screen.getByRole('button', { name: /Completar cadastro/i }));
+  await screen.findByLabelText(/Instituição/i);
+};
+
+const preencherPasso2 = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(screen.getByLabelText(/SIAPE/i), '1234567');
+  await user.type(screen.getByLabelText(/Departamento/i), 'Anatomia');
+  await user.type(screen.getByLabelText(/Curso/i), 'Medicina');
+};
+
+describe('RegisterProfessorForm', () => {
+  beforeEach(() => {
+    registerProfessorMock.mockReset();
+    registerProfessorMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renderiza o formulario com todos os campos ao avancar pelas etapas', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    expect(screen.getByLabelText(/Nome completo/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Email institucional/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Senha/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Confirmação de senha/i)).toBeInTheDocument();
+
+    await preencherPasso1(user);
+
+    expect(screen.getByLabelText(/Instituição/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/SIAPE/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Departamento/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Curso/i)).toBeInTheDocument();
+  });
+
+  it('mantem o botao desabilitado para email fora de @unb.br', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByLabelText(/Nome completo/i), 'Hilmer Rodrigues Neri');
+    await user.type(screen.getByLabelText(/Email institucional/i), 'hilmer@gmail.com');
+    await user.type(screen.getByLabelText(/^Senha/i), 'password123');
+    await user.type(screen.getByLabelText(/Confirmação de senha/i), 'password123');
+
+    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeDisabled();
+  });
+
+  it('rejeita email com subdominio UnB', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByLabelText(/Nome completo/i), 'Hilmer Rodrigues Neri');
+    await user.type(screen.getByLabelText(/Email institucional/i), 'hilmer@professor.unb.br');
+    await user.type(screen.getByLabelText(/^Senha/i), 'password123');
+    await user.type(screen.getByLabelText(/Confirmação de senha/i), 'password123');
+    await user.click(screen.getByLabelText(/Email institucional/i));
+    await user.tab();
+
+    expect(await screen.findByText(/@unb\.br/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeDisabled();
+  });
+
+  it('exibe erro para SIAPE com formato invalido', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await preencherPasso1(user);
+    await user.type(screen.getByLabelText(/SIAPE/i), '123456');
+    await user.click(screen.getByLabelText(/SIAPE/i));
+    await user.tab();
+
+    expect(await screen.findByText(/SIAPE deve conter exatamente 7 dígitos/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeDisabled();
+  });
+
+  it('mantem o botao desabilitado quando as senhas sao diferentes', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByLabelText(/Nome completo/i), 'Hilmer Rodrigues Neri');
+    await user.type(screen.getByLabelText(/Email institucional/i), 'hilmer@unb.br');
+    await user.type(screen.getByLabelText(/^Senha/i), 'password123');
+    await user.type(screen.getByLabelText(/Confirmação de senha/i), '12345678');
+
+    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeDisabled();
+  });
+
+  it('mantem instituicao pre-preenchida e bloqueada', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await preencherPasso1(user);
+
+    const institutionInput = screen.getByLabelText(/Instituição/i);
+    expect(institutionInput).toHaveValue(PROFESSOR_INSTITUTION);
+    expect(institutionInput).toBeDisabled();
+  });
+
+  it('envia cadastro com valores preenchidos e mostra confirmacao de analise', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await preencherPasso1(user);
+    await preencherPasso2(user);
+    await user.click(screen.getByRole('button', { name: /Completar cadastro/i }));
+
+    expect(registerProfessorMock).toHaveBeenCalledWith({
+      fullName: 'Hilmer Rodrigues Neri',
+      email: 'hilmer@unb.br',
+      password: 'password123',
+      confirmPassword: 'password123',
+      institution: PROFESSOR_INSTITUTION,
+      siape: '1234567',
+      department: 'Anatomia',
+      course: 'Medicina',
+    });
+    expect(await screen.findByText(/Cadastro realizado!/i)).toBeInTheDocument();
+    expect(screen.getByText(/Seu cadastro está em análise pelo administrador/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Voltar para login/i })).toHaveAttribute(
+      'href',
+      '/professor/login',
+    );
+  });
+
+  it('exibe erro inline no email quando a API retorna email ja cadastrado', async () => {
+    const user = userEvent.setup();
+    registerProfessorMock.mockRejectedValueOnce(
+      new RegisterProfessorError('Email ja cadastrado.', { email: 'Email ja cadastrado.' }),
+    );
+
+    renderForm();
+    await preencherPasso1(user);
+    await preencherPasso2(user);
+    await user.click(screen.getByRole('button', { name: /Completar cadastro/i }));
+
+    expect(await screen.findByText(/Email ja cadastrado/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Email institucional/i)).toBeInTheDocument();
+  });
+
+  it('exibe erro inline no SIAPE quando a API retorna SIAPE ja cadastrado', async () => {
+    const user = userEvent.setup();
+    registerProfessorMock.mockRejectedValueOnce(
+      new RegisterProfessorError('SIAPE ja cadastrado.', { siape: 'SIAPE ja cadastrado.' }),
+    );
+
+    renderForm();
+    await preencherPasso1(user);
+    await preencherPasso2(user);
+    await user.click(screen.getByRole('button', { name: /Completar cadastro/i }));
+
+    expect(await screen.findByText(/SIAPE ja cadastrado/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/SIAPE/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/register-professor/ui/RegisterProfessorForm.test.tsx
+++ b/src/features/register-professor/ui/RegisterProfessorForm.test.tsx
@@ -74,7 +74,7 @@ describe('RegisterProfessorForm', () => {
     expect(screen.getByLabelText(/Curso/i)).toBeInTheDocument();
   });
 
-  it('mantem o botao desabilitado para email fora de @unb.br', async () => {
+  it('mantem o botao desabilitado para email fora do dominio UnB', async () => {
     const user = userEvent.setup();
     renderForm();
 
@@ -86,7 +86,7 @@ describe('RegisterProfessorForm', () => {
     expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeDisabled();
   });
 
-  it('rejeita email com subdominio UnB', async () => {
+  it('aceita email com subdominio UnB', async () => {
     const user = userEvent.setup();
     renderForm();
 
@@ -94,11 +94,8 @@ describe('RegisterProfessorForm', () => {
     await user.type(screen.getByLabelText(/Email institucional/i), 'hilmer@professor.unb.br');
     await user.type(screen.getByLabelText(/^Senha/i), 'password123');
     await user.type(screen.getByLabelText(/Confirmação de senha/i), 'password123');
-    await user.click(screen.getByLabelText(/Email institucional/i));
-    await user.tab();
-
-    expect(await screen.findByText(/@unb\.br/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeDisabled();
+    expect(screen.queryByText(/Use um email institucional UnB/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeEnabled();
   });
 
   it('exibe erro para SIAPE com formato invalido', async () => {

--- a/src/features/register-professor/ui/RegisterProfessorForm.test.tsx
+++ b/src/features/register-professor/ui/RegisterProfessorForm.test.tsx
@@ -15,7 +15,7 @@ jest.mock('../model/registerProfessorService', () => {
   };
 });
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -24,6 +24,9 @@ import { PROFESSOR_INSTITUTION } from '../model/types';
 import { RegisterProfessorForm } from './RegisterProfessorForm';
 
 const registerProfessorMock = registerProfessor as jest.Mock;
+const VALID_PASSWORD = 'senhaValida123';
+const PROFESSOR_NAME = 'Hilmer Rodrigues Neri';
+const PROFESSOR_EMAIL = 'hilmer@unb.br';
 
 const renderForm = () =>
   render(
@@ -32,12 +35,14 @@ const renderForm = () =>
     </MemoryRouter>,
   );
 
+const submitButton = () => screen.getByRole('button', { name: /Completar cadastro/i });
+
 const preencherPasso1 = async (user: ReturnType<typeof userEvent.setup>) => {
-  await user.type(screen.getByLabelText(/Nome completo/i), 'Hilmer Rodrigues Neri');
-  await user.type(screen.getByLabelText(/Email institucional/i), 'hilmer@unb.br');
-  await user.type(screen.getByLabelText(/^Senha/i), 'password123');
-  await user.type(screen.getByLabelText(/Confirmação de senha/i), 'password123');
-  await user.click(screen.getByRole('button', { name: /Completar cadastro/i }));
+  await user.type(screen.getByLabelText(/Nome completo/i), PROFESSOR_NAME);
+  await user.type(screen.getByLabelText(/Email institucional/i), PROFESSOR_EMAIL);
+  await user.type(screen.getByLabelText(/^Senha/i), VALID_PASSWORD);
+  await user.type(screen.getByLabelText(/Confirmação de senha/i), VALID_PASSWORD);
+  await user.click(submitButton());
   await screen.findByLabelText(/Instituição/i);
 };
 
@@ -78,24 +83,25 @@ describe('RegisterProfessorForm', () => {
     const user = userEvent.setup();
     renderForm();
 
-    await user.type(screen.getByLabelText(/Nome completo/i), 'Hilmer Rodrigues Neri');
+    await user.type(screen.getByLabelText(/Nome completo/i), PROFESSOR_NAME);
     await user.type(screen.getByLabelText(/Email institucional/i), 'hilmer@gmail.com');
-    await user.type(screen.getByLabelText(/^Senha/i), 'password123');
-    await user.type(screen.getByLabelText(/Confirmação de senha/i), 'password123');
+    await user.type(screen.getByLabelText(/^Senha/i), VALID_PASSWORD);
+    await user.type(screen.getByLabelText(/Confirmação de senha/i), VALID_PASSWORD);
 
-    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeDisabled();
+    expect(submitButton()).toBeDisabled();
   });
 
   it('aceita email com subdominio UnB', async () => {
     const user = userEvent.setup();
     renderForm();
 
-    await user.type(screen.getByLabelText(/Nome completo/i), 'Hilmer Rodrigues Neri');
+    await user.type(screen.getByLabelText(/Nome completo/i), PROFESSOR_NAME);
     await user.type(screen.getByLabelText(/Email institucional/i), 'hilmer@professor.unb.br');
-    await user.type(screen.getByLabelText(/^Senha/i), 'password123');
-    await user.type(screen.getByLabelText(/Confirmação de senha/i), 'password123');
+    await user.type(screen.getByLabelText(/^Senha/i), VALID_PASSWORD);
+    await user.type(screen.getByLabelText(/Confirmação de senha/i), VALID_PASSWORD);
+
     expect(screen.queryByText(/Use um email institucional UnB/i)).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeEnabled();
+    expect(submitButton()).toBeEnabled();
   });
 
   it('exibe erro para SIAPE com formato invalido', async () => {
@@ -108,19 +114,44 @@ describe('RegisterProfessorForm', () => {
     await user.tab();
 
     expect(await screen.findByText(/SIAPE deve conter exatamente 7 dígitos/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeDisabled();
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it('remove caracteres nao numericos do SIAPE', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await preencherPasso1(user);
+    await user.type(screen.getByLabelText(/SIAPE/i), '12a34-567');
+
+    expect(screen.getByLabelText(/SIAPE/i)).toHaveValue('1234567');
   });
 
   it('mantem o botao desabilitado quando as senhas sao diferentes', async () => {
     const user = userEvent.setup();
     renderForm();
 
-    await user.type(screen.getByLabelText(/Nome completo/i), 'Hilmer Rodrigues Neri');
-    await user.type(screen.getByLabelText(/Email institucional/i), 'hilmer@unb.br');
-    await user.type(screen.getByLabelText(/^Senha/i), 'password123');
-    await user.type(screen.getByLabelText(/Confirmação de senha/i), '12345678');
+    await user.type(screen.getByLabelText(/Nome completo/i), PROFESSOR_NAME);
+    await user.type(screen.getByLabelText(/Email institucional/i), PROFESSOR_EMAIL);
+    await user.type(screen.getByLabelText(/^Senha/i), VALID_PASSWORD);
+    await user.type(screen.getByLabelText(/Confirmação de senha/i), 'senhaDiferente123');
 
-    expect(screen.getByRole('button', { name: /Completar cadastro/i })).toBeDisabled();
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it('revalida confirmacao quando a senha muda depois de tocada', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByLabelText(/Nome completo/i), PROFESSOR_NAME);
+    await user.type(screen.getByLabelText(/Email institucional/i), PROFESSOR_EMAIL);
+    await user.type(screen.getByLabelText(/^Senha/i), VALID_PASSWORD);
+    await user.type(screen.getByLabelText(/Confirmação de senha/i), VALID_PASSWORD);
+    await user.tab();
+    await user.clear(screen.getByLabelText(/^Senha/i));
+    await user.type(screen.getByLabelText(/^Senha/i), 'senhaAlterada123');
+
+    expect(await screen.findByText(/As senhas não coincidem/i)).toBeInTheDocument();
   });
 
   it('mantem instituicao pre-preenchida e bloqueada', async () => {
@@ -134,19 +165,42 @@ describe('RegisterProfessorForm', () => {
     expect(institutionInput).toBeDisabled();
   });
 
+  it('volta para a etapa anterior mantendo os dados preenchidos', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await preencherPasso1(user);
+    await user.click(screen.getByRole('button', { name: /Voltar etapa/i }));
+
+    expect(screen.getByLabelText(/Email institucional/i)).toHaveValue(PROFESSOR_EMAIL);
+    expect(screen.queryByLabelText(/SIAPE/i)).not.toBeInTheDocument();
+  });
+
+  it('exibe validacoes obrigatorias quando o formulario da segunda etapa e enviado vazio', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await preencherPasso1(user);
+    fireEvent.submit(screen.getByRole('form', { name: /register professor form/i }));
+
+    expect(await screen.findByText(/SIAPE é obrigatório/i)).toBeInTheDocument();
+    expect(screen.getByText(/Departamento é obrigatório/i)).toBeInTheDocument();
+    expect(screen.getByText(/Curso é obrigatório/i)).toBeInTheDocument();
+  });
+
   it('envia cadastro com valores preenchidos e mostra confirmacao de analise', async () => {
     const user = userEvent.setup();
     renderForm();
 
     await preencherPasso1(user);
     await preencherPasso2(user);
-    await user.click(screen.getByRole('button', { name: /Completar cadastro/i }));
+    await user.click(submitButton());
 
     expect(registerProfessorMock).toHaveBeenCalledWith({
-      fullName: 'Hilmer Rodrigues Neri',
-      email: 'hilmer@unb.br',
-      password: 'password123',
-      confirmPassword: 'password123',
+      fullName: PROFESSOR_NAME,
+      email: PROFESSOR_EMAIL,
+      password: VALID_PASSWORD,
+      confirmPassword: VALID_PASSWORD,
       institution: PROFESSOR_INSTITUTION,
       siape: '1234567',
       department: 'Anatomia',
@@ -160,6 +214,25 @@ describe('RegisterProfessorForm', () => {
     );
   });
 
+  it('mostra carregamento enquanto a API processa o cadastro', async () => {
+    const user = userEvent.setup();
+    let resolveRequest: () => void = () => undefined;
+    registerProfessorMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    renderForm();
+    await preencherPasso1(user);
+    await preencherPasso2(user);
+    await user.click(submitButton());
+
+    expect(await screen.findByRole('button', { name: /Finalizando/i })).toBeDisabled();
+    resolveRequest();
+    expect(await screen.findByText(/Cadastro realizado!/i)).toBeInTheDocument();
+  });
+
   it('exibe erro inline no email quando a API retorna email ja cadastrado', async () => {
     const user = userEvent.setup();
     registerProfessorMock.mockRejectedValueOnce(
@@ -169,7 +242,7 @@ describe('RegisterProfessorForm', () => {
     renderForm();
     await preencherPasso1(user);
     await preencherPasso2(user);
-    await user.click(screen.getByRole('button', { name: /Completar cadastro/i }));
+    await user.click(submitButton());
 
     expect(await screen.findByText(/Email ja cadastrado/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Email institucional/i)).toBeInTheDocument();
@@ -184,9 +257,35 @@ describe('RegisterProfessorForm', () => {
     renderForm();
     await preencherPasso1(user);
     await preencherPasso2(user);
-    await user.click(screen.getByRole('button', { name: /Completar cadastro/i }));
+    await user.click(submitButton());
 
     expect(await screen.findByText(/SIAPE ja cadastrado/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/SIAPE/i)).toBeInTheDocument();
+  });
+
+  it('exibe erro geral quando a API retorna RegisterProfessorError sem campo', async () => {
+    const user = userEvent.setup();
+    registerProfessorMock.mockRejectedValueOnce(new RegisterProfessorError('Servidor indisponivel.'));
+
+    renderForm();
+    await preencherPasso1(user);
+    await preencherPasso2(user);
+    await user.click(submitButton());
+
+    expect(await screen.findByText(/Servidor indisponivel/i)).toBeInTheDocument();
+  });
+
+  it('exibe erro geral quando ocorre falha desconhecida', async () => {
+    const user = userEvent.setup();
+    registerProfessorMock.mockRejectedValueOnce(new Error('falha inesperada'));
+
+    renderForm();
+    await preencherPasso1(user);
+    await preencherPasso2(user);
+    await user.click(submitButton());
+
+    expect(
+      await screen.findByText(/Não foi possível concluir o cadastro. Tente novamente/i),
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/register-professor/ui/RegisterProfessorForm.tsx
+++ b/src/features/register-professor/ui/RegisterProfessorForm.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ArrowLeft, LockKeyhole } from 'lucide-react';
+import { ArrowLeft, Clock3, LockKeyhole } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import {
   RegisterProfessorError,
@@ -28,26 +28,125 @@ const STEP_FIELDS: Record<number, RegisterProfessorField[]> = {
   2: ['institution', 'siape', 'department', 'course'],
 };
 
-const INPUT_CLASS =
-  'h-10 w-full rounded-[7px] border px-3.5 text-sm text-[#0A1128] outline-none transition-colors ' +
-  'placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] bg-white';
-
+const PROFESSOR_LOGIN_ROUTE = '/professor/login';
+const SUBMIT_LABEL = 'Completar cadastro';
+const GENERIC_REGISTER_ERROR = 'Não foi possível concluir o cadastro. Tente novamente.';
 const EMAIL_UNB_REGEX = /^[^\s@]+@(?:[a-z0-9-]+\.)*unb\.br$/i;
 const SIAPE_REGEX = /^\d{7}$/;
 
-type TextFieldProps = {
+type FieldValidator = (values: RegisterProfessorFormValues) => string | undefined;
+
+const requiredText = (value: string, message: string) => (value.trim() ? undefined : message);
+
+const FIELD_VALIDATORS: Record<RegisterProfessorField, FieldValidator> = {
+  fullName: (values) => requiredText(values.fullName, 'Nome completo é obrigatório.'),
+  email: (values) => {
+    const email = values.email.trim();
+    if (!email) return 'Email institucional é obrigatório.';
+    return EMAIL_UNB_REGEX.test(email) ? undefined : 'Use um email institucional UnB.';
+  },
+  password: (values) => {
+    if (!values.password) return 'Senha é obrigatória.';
+    return values.password.length >= 8 ? undefined : 'A senha deve ter no mínimo 8 caracteres.';
+  },
+  confirmPassword: (values) => {
+    if (!values.confirmPassword) return 'Confirmação de senha é obrigatória.';
+    return values.confirmPassword === values.password ? undefined : 'As senhas não coincidem.';
+  },
+  institution: (values) =>
+    values.institution === PROFESSOR_INSTITUTION ? undefined : 'Instituição inválida.',
+  siape: (values) => {
+    const siape = values.siape.trim();
+    if (!siape) return 'SIAPE é obrigatório.';
+    return SIAPE_REGEX.test(siape) ? undefined : 'SIAPE deve conter exatamente 7 dígitos.';
+  },
+  department: (values) => requiredText(values.department, 'Departamento é obrigatório.'),
+  course: (values) => requiredText(values.course, 'Curso é obrigatório.'),
+};
+
+const validateField = (
+  values: RegisterProfessorFormValues,
+  field: RegisterProfessorField,
+): string | undefined => FIELD_VALIDATORS[field](values);
+
+const validateFields = (
+  values: RegisterProfessorFormValues,
+  fields: RegisterProfessorField[],
+): RegisterProfessorFieldErrors =>
+  fields.reduce<RegisterProfessorFieldErrors>((fieldErrors, field) => {
+    const error = validateField(values, field);
+    if (error) fieldErrors[field] = error;
+    return fieldErrors;
+  }, {});
+
+const touchedFieldsFrom = (fields: RegisterProfessorField[]) =>
+  fields.reduce<Partial<Record<RegisterProfessorField, boolean>>>((touched, field) => {
+    touched[field] = true;
+    return touched;
+  }, {});
+
+const mergeFieldErrors = (
+  previous: RegisterProfessorFieldErrors,
+  fields: RegisterProfessorField[],
+  nextErrors: RegisterProfessorFieldErrors,
+) => {
+  const updated = { ...previous };
+
+  fields.forEach((field) => {
+    if (nextErrors[field]) {
+      updated[field] = nextErrors[field];
+    } else {
+      delete updated[field];
+    }
+  });
+
+  return updated;
+};
+
+const getStepByField = (field: RegisterProfessorField): number =>
+  STEP_FIELDS[1].includes(field) ? 1 : 2;
+
+type TextFieldConfig = {
   label: string;
   name: RegisterProfessorField;
-  value: string;
   type?: 'text' | 'email' | 'password';
   inputMode?: 'numeric';
-  error?: string;
   maxLength?: number;
+  normalize?: (value: string) => string;
+};
+
+const STEP_ONE_TEXT_FIELDS: TextFieldConfig[] = [
+  { label: 'Nome Completo', name: 'fullName' },
+  { label: 'Email Institucional', name: 'email', type: 'email' },
+  { label: 'Senha', name: 'password', type: 'password' },
+  { label: 'Confirmação de senha', name: 'confirmPassword', type: 'password' },
+];
+
+const STEP_TWO_TEXT_FIELDS: TextFieldConfig[] = [
+  { label: 'SIAPE', name: 'siape', inputMode: 'numeric', maxLength: 7, normalize: onlyDigits },
+  { label: 'Departamento', name: 'department' },
+  { label: 'Curso', name: 'course' },
+];
+
+function onlyDigits(value: string) {
+  return value.replace(/\D/g, '');
+}
+
+type ProfessorTextFieldProps = TextFieldConfig & {
+  value: string;
+  error?: string;
   onBlur: (name: RegisterProfessorField) => void;
   onChange: (name: RegisterProfessorField, value: string) => void;
 };
 
-const TextField = ({
+const inputClassName = (hasError: boolean) =>
+  [
+    'h-10 w-full rounded-[7px] border px-3.5 text-sm text-[#0A1128] outline-none',
+    'transition-colors placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] bg-white',
+    hasError ? 'border-red-400' : 'border-[#14D5C2]',
+  ].join(' ');
+
+const ProfessorTextField = ({
   label,
   name,
   value,
@@ -55,9 +154,10 @@ const TextField = ({
   inputMode,
   error,
   maxLength,
+  normalize,
   onBlur,
   onChange,
-}: TextFieldProps) => (
+}: ProfessorTextFieldProps) => (
   <div className="flex flex-col gap-1.5">
     <label htmlFor={name} className="text-xs font-medium text-[#0A1128]">
       {label}
@@ -70,9 +170,9 @@ const TextField = ({
       value={value}
       maxLength={maxLength}
       aria-invalid={!!error}
-      className={`${INPUT_CLASS} ${error ? 'border-red-400' : 'border-[#14D5C2]'}`}
+      className={inputClassName(!!error)}
       onBlur={() => onBlur(name)}
-      onChange={(event) => onChange(name, event.target.value)}
+      onChange={(event) => onChange(name, normalize?.(event.target.value) ?? event.target.value)}
     />
     {error ? <span className="text-xs font-medium text-red-500">{error}</span> : null}
   </div>
@@ -113,92 +213,11 @@ const LockedInstitutionField = ({ value, error }: LockedInstitutionFieldProps) =
   </div>
 );
 
-const validateField = (
-  values: RegisterProfessorFormValues,
-  field: RegisterProfessorField,
-): string | undefined => {
-  const value = values[field];
-  const trimmedValue = value.trim();
-
-  switch (field) {
-    case 'fullName':
-      if (!trimmedValue) return 'Nome completo é obrigatório.';
-      return undefined;
-    case 'email':
-      if (!trimmedValue) return 'Email institucional é obrigatório.';
-      if (!EMAIL_UNB_REGEX.test(trimmedValue)) {
-        return 'Use um email institucional UnB.';
-      }
-      return undefined;
-    case 'password':
-      if (!value) return 'Senha é obrigatória.';
-      if (value.length < 8) return 'A senha deve ter no mínimo 8 caracteres.';
-      return undefined;
-    case 'confirmPassword':
-      if (!value) return 'Confirmação de senha é obrigatória.';
-      if (value !== values.password) return 'As senhas não coincidem.';
-      return undefined;
-    case 'institution':
-      if (value !== PROFESSOR_INSTITUTION) return 'Instituição inválida.';
-      return undefined;
-    case 'siape':
-      if (!trimmedValue) return 'SIAPE é obrigatório.';
-      if (!SIAPE_REGEX.test(trimmedValue)) return 'SIAPE deve conter exatamente 7 dígitos.';
-      return undefined;
-    case 'department':
-      if (!trimmedValue) return 'Departamento é obrigatório.';
-      return undefined;
-    case 'course':
-      if (!trimmedValue) return 'Curso é obrigatório.';
-      return undefined;
-    default:
-      return undefined;
-  }
-};
-
-const validateFields = (
-  values: RegisterProfessorFormValues,
-  fields: RegisterProfessorField[],
-): RegisterProfessorFieldErrors =>
-  fields.reduce<RegisterProfessorFieldErrors>((fieldErrors, field) => {
-    const error = validateField(values, field);
-    if (error) fieldErrors[field] = error;
-    return fieldErrors;
-  }, {});
-
-const touchedFieldsFrom = (fields: RegisterProfessorField[]) =>
-  fields.reduce<Partial<Record<RegisterProfessorField, boolean>>>((touched, field) => {
-    touched[field] = true;
-    return touched;
-  }, {});
-
-const mergeFieldErrors = (
-  previous: RegisterProfessorFieldErrors,
-  fields: RegisterProfessorField[],
-  nextErrors: RegisterProfessorFieldErrors,
-) => {
-  const updated = { ...previous };
-
-  fields.forEach((field) => {
-    if (nextErrors[field]) {
-      updated[field] = nextErrors[field];
-    } else {
-      delete updated[field];
-    }
-  });
-
-  return updated;
-};
-
-const getStepByField = (field: RegisterProfessorField): number => (
-  STEP_FIELDS[1].includes(field) ? 1 : 2
-);
-
 type StepperProps = {
   step: number;
 };
 
-const Stepper = ({ step }: StepperProps) => (
+const ProfessorStepper = ({ step }: StepperProps) => (
   <div className="mb-6 flex w-full items-center [@media(max-height:760px)]:mb-4">
     {[1, 2, 3].map((marker, index) => (
       <div key={`professor-step-${marker}`} className="flex flex-1 items-center last:flex-none">
@@ -328,31 +347,40 @@ export const RegisterProfessorForm = () => {
           setFormError(error.message);
         }
       } else {
-        setFormError('Não foi possível concluir o cadastro. Tente novamente.');
+        setFormError(GENERIC_REGISTER_ERROR);
       }
     } finally {
       setIsLoading(false);
     }
   };
 
+  const renderTextField = (config: TextFieldConfig) => (
+    <ProfessorTextField
+      key={config.name}
+      {...config}
+      value={values[config.name]}
+      onBlur={markTouchedAndValidate}
+      onChange={handleTextChange}
+      error={errors[config.name]}
+    />
+  );
+
   if (isSuccess) {
     return (
       <section className="w-full max-w-[470px]">
-        <Stepper step={3} />
+        <ProfessorStepper step={3} />
         <div className="rounded-[7px] border border-[#14D5C2] bg-[#EFF3FB] p-4 text-sm text-[#0A1128]">
           <h2 className="text-2xl font-bold text-[#0A1128]">Cadastro completo!</h2>
           <div className="mt-3 flex w-full items-start gap-3 rounded-[7px] border border-[#F5A623] bg-[#E6E4FC] px-3 py-3 text-[#7A4F00]">
-          <span className="text-lg" aria-hidden="true">
-            ⏳
-          </span>
-          <p className="text-xs font-semibold leading-5">
-            <strong>Cadastro realizado!</strong>
-            <br />
-            Seu cadastro está em análise pelo administrador. Você poderá acessar a plataforma após
-            aprovação.
-          </p>
-        </div>
-          <Link to="/professor/login" className="mt-3 inline-block text-[#00AFA0] underline">
+            <Clock3 className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <p className="text-xs font-semibold leading-5">
+              <strong>Cadastro realizado!</strong>
+              <br />
+              Seu cadastro está em análise pelo administrador. Você poderá acessar a plataforma
+              após aprovação.
+            </p>
+          </div>
+          <Link to={PROFESSOR_LOGIN_ROUTE} className="mt-3 inline-block text-[#00AFA0] underline">
             Voltar para login
           </Link>
         </div>
@@ -362,12 +390,12 @@ export const RegisterProfessorForm = () => {
 
   return (
     <section className="w-full max-w-[470px]">
-      <Stepper step={step} />
+      <ProfessorStepper step={step} />
 
       <div className="mb-6 [@media(max-height:760px)]:mb-4">
         <h2 className="text-xl font-bold leading-tight text-[#0A1128]">Complete seu perfil</h2>
         <p className="mt-2 max-w-[440px] text-xs leading-5 text-[#0A1128]/65">
-          para continuar preencha o formulário — Acesso para professores
+          Para continuar, preencha o formulário de acesso para professores.
         </p>
       </div>
 
@@ -384,79 +412,20 @@ export const RegisterProfessorForm = () => {
         noValidate
         className="flex flex-col gap-4 [@media(max-height:760px)]:gap-3"
       >
-        {step === 1 ? (
-          <>
-            <TextField
-              label="Nome Completo"
-              name="fullName"
-              value={values.fullName}
-              onBlur={markTouchedAndValidate}
-              onChange={handleTextChange}
-              error={errors.fullName}
-            />
-            <TextField
-              label="Email Institucional"
-              name="email"
-              value={values.email}
-              type="email"
-              onBlur={markTouchedAndValidate}
-              onChange={handleTextChange}
-              error={errors.email}
-            />
-            <TextField
-              label="Senha"
-              name="password"
-              value={values.password}
-              type="password"
-              onBlur={markTouchedAndValidate}
-              onChange={handleTextChange}
-              error={errors.password}
-            />
-            <TextField
-              label="Confirmação de senha"
-              name="confirmPassword"
-              value={values.confirmPassword}
-              type="password"
-              onBlur={markTouchedAndValidate}
-              onChange={handleTextChange}
-              error={errors.confirmPassword}
-            />
-          </>
-        ) : null}
+        {step === 1 ? <>{STEP_ONE_TEXT_FIELDS.map(renderTextField)}</> : null}
 
         {step === 2 ? (
           <>
             <LockedInstitutionField value={values.institution} error={errors.institution} />
-            <TextField
-              label="SIAPE"
-              name="siape"
-              value={values.siape}
-              inputMode="numeric"
-              maxLength={7}
-              onBlur={markTouchedAndValidate}
-              onChange={(field, value) => handleTextChange(field, value.replace(/\D/g, ''))}
-              error={errors.siape}
-            />
-            <TextField
-              label="Departamento"
-              name="department"
-              value={values.department}
-              onBlur={markTouchedAndValidate}
-              onChange={handleTextChange}
-              error={errors.department}
-            />
-            <TextField
-              label="Curso"
-              name="course"
-              value={values.course}
-              onBlur={markTouchedAndValidate}
-              onChange={handleTextChange}
-              error={errors.course}
-            />
+            {STEP_TWO_TEXT_FIELDS.map(renderTextField)}
           </>
         ) : null}
 
-        {formError ? <span className="text-xs font-medium text-red-500">{formError}</span> : null}
+        {formError ? (
+          <span aria-live="polite" className="text-xs font-medium text-red-500">
+            {formError}
+          </span>
+        ) : null}
 
         {step > 1 ? (
           <button
@@ -473,11 +442,11 @@ export const RegisterProfessorForm = () => {
           disabled={!isCurrentStepValid}
           className="mt-1 h-10 w-full cursor-pointer rounded-[7px] bg-[#14D5C2] px-4 text-sm font-bold text-[#0A1128] transition-colors hover:brightness-95 disabled:cursor-not-allowed disabled:bg-[#9FE7DF] disabled:text-[#0A1128]/55"
         >
-          {isLoading ? 'Finalizando...' : 'Completar cadastro'}
+          {isLoading ? 'Finalizando...' : SUBMIT_LABEL}
         </button>
 
         <Link
-          to="/professor/login"
+          to={PROFESSOR_LOGIN_ROUTE}
           className="mt-3 inline-flex items-center justify-center gap-1.5 text-sm font-bold text-[#00AFA0] transition-colors hover:text-[#0A1128]"
         >
           <ArrowLeft className="h-4 w-4" aria-hidden="true" />

--- a/src/features/register-professor/ui/RegisterProfessorForm.tsx
+++ b/src/features/register-professor/ui/RegisterProfessorForm.tsx
@@ -1,0 +1,489 @@
+import { useMemo, useState } from 'react';
+import { ArrowLeft, LockKeyhole } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import {
+  RegisterProfessorError,
+  registerProfessor,
+} from '../model/registerProfessorService';
+import {
+  PROFESSOR_INSTITUTION,
+  type RegisterProfessorField,
+  type RegisterProfessorFieldErrors,
+  type RegisterProfessorFormValues,
+} from '../model/types';
+
+const INITIAL_VALUES: RegisterProfessorFormValues = {
+  fullName: '',
+  email: '',
+  password: '',
+  confirmPassword: '',
+  institution: PROFESSOR_INSTITUTION,
+  siape: '',
+  department: '',
+  course: '',
+};
+
+const STEP_FIELDS: Record<number, RegisterProfessorField[]> = {
+  1: ['fullName', 'email', 'password', 'confirmPassword'],
+  2: ['institution', 'siape', 'department', 'course'],
+};
+
+const INPUT_CLASS =
+  'h-10 w-full rounded-[7px] border px-3.5 text-sm text-[#0A1128] outline-none transition-colors ' +
+  'placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] bg-white';
+
+const EMAIL_UNB_REGEX = /^[^\s@]+@unb\.br$/i;
+const SIAPE_REGEX = /^\d{7}$/;
+
+type TextFieldProps = {
+  label: string;
+  name: RegisterProfessorField;
+  value: string;
+  type?: 'text' | 'email' | 'password';
+  inputMode?: 'numeric';
+  error?: string;
+  maxLength?: number;
+  onBlur: (name: RegisterProfessorField) => void;
+  onChange: (name: RegisterProfessorField, value: string) => void;
+};
+
+const TextField = ({
+  label,
+  name,
+  value,
+  type = 'text',
+  inputMode,
+  error,
+  maxLength,
+  onBlur,
+  onChange,
+}: TextFieldProps) => (
+  <div className="flex flex-col gap-1.5">
+    <label htmlFor={name} className="text-xs font-medium text-[#0A1128]">
+      {label}
+    </label>
+    <input
+      id={name}
+      name={name}
+      type={type}
+      inputMode={inputMode}
+      value={value}
+      maxLength={maxLength}
+      aria-invalid={!!error}
+      className={`${INPUT_CLASS} ${error ? 'border-red-400' : 'border-[#14D5C2]'}`}
+      onBlur={() => onBlur(name)}
+      onChange={(event) => onChange(name, event.target.value)}
+    />
+    {error ? <span className="text-xs font-medium text-red-500">{error}</span> : null}
+  </div>
+);
+
+type LockedInstitutionFieldProps = {
+  value: string;
+  error?: string;
+};
+
+const LockedInstitutionField = ({ value, error }: LockedInstitutionFieldProps) => (
+  <div className="flex flex-col gap-1.5">
+    <div className="flex items-center gap-1.5">
+      <label htmlFor="institution" className="text-xs font-medium text-[#0A1128]">
+        Instituição
+      </label>
+      <span className="inline-flex items-center gap-1 rounded-[4px] border border-[#BBD7D3] bg-[#F3F6FA] px-1.5 py-0.5 text-[10px] font-medium text-[#0A1128]/65">
+        <LockKeyhole className="h-2.5 w-2.5" aria-hidden="true" />
+        UnB
+      </span>
+    </div>
+    <div
+      className={`flex h-10 w-full items-center gap-2 rounded-[7px] border bg-[#F3F6FA] px-3.5 text-sm text-[#0A1128]/65 ${
+        error ? 'border-red-400' : 'border-[#BBD7D3]'
+      }`}
+    >
+      <LockKeyhole className="h-3.5 w-3.5 text-[#0A1128]/45" aria-hidden="true" />
+      <input
+        id="institution"
+        name="institution"
+        value={value}
+        disabled
+        readOnly
+        className="w-full bg-transparent outline-none disabled:cursor-not-allowed"
+      />
+    </div>
+    {error ? <span className="text-xs font-medium text-red-500">{error}</span> : null}
+  </div>
+);
+
+const validateField = (
+  values: RegisterProfessorFormValues,
+  field: RegisterProfessorField,
+): string | undefined => {
+  const value = values[field];
+  const trimmedValue = value.trim();
+
+  switch (field) {
+    case 'fullName':
+      if (!trimmedValue) return 'Nome completo é obrigatório.';
+      return undefined;
+    case 'email':
+      if (!trimmedValue) return 'Email institucional é obrigatório.';
+      if (!EMAIL_UNB_REGEX.test(trimmedValue)) {
+        return 'Use um email institucional @unb.br.';
+      }
+      return undefined;
+    case 'password':
+      if (!value) return 'Senha é obrigatória.';
+      if (value.length < 8) return 'A senha deve ter no mínimo 8 caracteres.';
+      return undefined;
+    case 'confirmPassword':
+      if (!value) return 'Confirmação de senha é obrigatória.';
+      if (value !== values.password) return 'As senhas não coincidem.';
+      return undefined;
+    case 'institution':
+      if (value !== PROFESSOR_INSTITUTION) return 'Instituição inválida.';
+      return undefined;
+    case 'siape':
+      if (!trimmedValue) return 'SIAPE é obrigatório.';
+      if (!SIAPE_REGEX.test(trimmedValue)) return 'SIAPE deve conter exatamente 7 dígitos.';
+      return undefined;
+    case 'department':
+      if (!trimmedValue) return 'Departamento é obrigatório.';
+      return undefined;
+    case 'course':
+      if (!trimmedValue) return 'Curso é obrigatório.';
+      return undefined;
+    default:
+      return undefined;
+  }
+};
+
+const validateFields = (
+  values: RegisterProfessorFormValues,
+  fields: RegisterProfessorField[],
+): RegisterProfessorFieldErrors =>
+  fields.reduce<RegisterProfessorFieldErrors>((fieldErrors, field) => {
+    const error = validateField(values, field);
+    if (error) fieldErrors[field] = error;
+    return fieldErrors;
+  }, {});
+
+const touchedFieldsFrom = (fields: RegisterProfessorField[]) =>
+  fields.reduce<Partial<Record<RegisterProfessorField, boolean>>>((touched, field) => {
+    touched[field] = true;
+    return touched;
+  }, {});
+
+const mergeFieldErrors = (
+  previous: RegisterProfessorFieldErrors,
+  fields: RegisterProfessorField[],
+  nextErrors: RegisterProfessorFieldErrors,
+) => {
+  const updated = { ...previous };
+
+  fields.forEach((field) => {
+    if (nextErrors[field]) {
+      updated[field] = nextErrors[field];
+    } else {
+      delete updated[field];
+    }
+  });
+
+  return updated;
+};
+
+const getStepByField = (field: RegisterProfessorField): number => (
+  STEP_FIELDS[1].includes(field) ? 1 : 2
+);
+
+type StepperProps = {
+  step: number;
+};
+
+const Stepper = ({ step }: StepperProps) => (
+  <div className="mb-6 flex w-full items-center [@media(max-height:760px)]:mb-4">
+    {[1, 2, 3].map((marker, index) => (
+      <div key={`professor-step-${marker}`} className="flex flex-1 items-center last:flex-none">
+        <div
+          className={[
+            'z-10 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold',
+            marker === step ? 'border-2 border-[#14D5C2] bg-[#0A1128] text-white' : '',
+            marker < step ? 'bg-[#14D5C2] text-[#0A1128]' : '',
+            marker > step ? 'bg-[#D6EEEA] text-[#73A69F]' : '',
+          ].join(' ')}
+        >
+          {marker}
+        </div>
+        {index < 2 ? (
+          <span
+            className={`mx-3 h-px flex-1 ${marker < step ? 'bg-[#14D5C2]' : 'bg-[#D6EEEA]'}`}
+          />
+        ) : null}
+      </div>
+    ))}
+  </div>
+);
+
+export const RegisterProfessorForm = () => {
+  const [values, setValues] = useState<RegisterProfessorFormValues>(INITIAL_VALUES);
+  const [errors, setErrors] = useState<RegisterProfessorFieldErrors>({});
+  const [touchedFields, setTouchedFields] = useState<
+    Partial<Record<RegisterProfessorField, boolean>>
+  >({});
+  const [step, setStep] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [formError, setFormError] = useState('');
+
+  const currentStepErrors = useMemo(
+    () => validateFields(values, STEP_FIELDS[step]),
+    [step, values],
+  );
+  const hasVisibleStepError = STEP_FIELDS[step].some((field) => !!errors[field]);
+  const isCurrentStepValid =
+    Object.keys(currentStepErrors).length === 0 && !hasVisibleStepError && !isLoading;
+
+  const updateFieldError = (
+    field: RegisterProfessorField,
+    nextValues: RegisterProfessorFormValues,
+  ) => {
+    const error = validateField(nextValues, field);
+    setErrors((previous) => {
+      const updated = { ...previous };
+      if (error) {
+        updated[field] = error;
+      } else {
+        delete updated[field];
+      }
+      return updated;
+    });
+  };
+
+  const markTouchedAndValidate = (field: RegisterProfessorField) => {
+    setTouchedFields((previous) => ({ ...previous, [field]: true }));
+    updateFieldError(field, values);
+  };
+
+  const handleTextChange = (field: RegisterProfessorField, value: string) => {
+    const nextValues = { ...values, [field]: value };
+    setValues(nextValues);
+    if (formError) setFormError('');
+
+    if (touchedFields[field] || errors[field]) updateFieldError(field, nextValues);
+    if (field === 'password' && (touchedFields.confirmPassword || errors.confirmPassword)) {
+      updateFieldError('confirmPassword', nextValues);
+    }
+  };
+
+  const goToNextStep = () => {
+    const stepFields = STEP_FIELDS[step];
+    const stepErrors = validateFields(values, stepFields);
+
+    setTouchedFields((previous) => ({ ...previous, ...touchedFieldsFrom(stepFields) }));
+    setErrors((previous) => mergeFieldErrors(previous, stepFields, stepErrors));
+
+    if (Object.keys(stepErrors).length > 0) return;
+
+    setFormError('');
+    setStep((current) => Math.min(current + 1, 2));
+  };
+
+  const goToPreviousStep = () => {
+    setFormError('');
+    setStep((current) => Math.max(current - 1, 1));
+  };
+
+  const handleSubmit = async () => {
+    const allFields = [...STEP_FIELDS[1], ...STEP_FIELDS[2]];
+    const validationErrors = validateFields(values, allFields);
+
+    setTouchedFields((previous) => ({ ...previous, ...touchedFieldsFrom(allFields) }));
+
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors((previous) => mergeFieldErrors(previous, allFields, validationErrors));
+      const firstErrorField = Object.keys(validationErrors)[0] as RegisterProfessorField;
+      setStep(getStepByField(firstErrorField));
+      return;
+    }
+
+    setErrors({});
+    setFormError('');
+    setIsLoading(true);
+
+    try {
+      await registerProfessor(values);
+      setIsSuccess(true);
+    } catch (error) {
+      if (error instanceof RegisterProfessorError) {
+        const fieldErrors = error.fieldErrors;
+
+        if (fieldErrors) {
+          setErrors((previous) => ({ ...previous, ...fieldErrors }));
+          setTouchedFields((previous) => ({
+            ...previous,
+            ...touchedFieldsFrom(Object.keys(fieldErrors) as RegisterProfessorField[]),
+          }));
+          const firstField = Object.keys(fieldErrors)[0] as RegisterProfessorField | undefined;
+          if (firstField) setStep(getStepByField(firstField));
+          setFormError('');
+        } else {
+          setFormError(error.message);
+        }
+      } else {
+        setFormError('Não foi possível concluir o cadastro. Tente novamente.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isSuccess) {
+    return (
+      <section className="w-full max-w-[470px]">
+        <Stepper step={3} />
+        <div className="rounded-[7px] border border-[#14D5C2] bg-[#EFF3FB] p-4 text-sm text-[#0A1128]">
+          <h2 className="text-2xl font-bold text-[#0A1128]">Cadastro completo!</h2>
+          <div className="mt-3 flex w-full items-start gap-3 rounded-[7px] border border-[#F5A623] bg-[#E6E4FC] px-3 py-3 text-[#7A4F00]">
+          <span className="text-lg" aria-hidden="true">
+            ⏳
+          </span>
+          <p className="text-xs font-semibold leading-5">
+            <strong>Cadastro realizado!</strong>
+            <br />
+            Seu cadastro está em análise pelo administrador. Você poderá acessar a plataforma após
+            aprovação.
+          </p>
+        </div>
+          <Link to="/professor/login" className="mt-3 inline-block text-[#00AFA0] underline">
+            Voltar para login
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="w-full max-w-[470px]">
+      <Stepper step={step} />
+
+      <div className="mb-6 [@media(max-height:760px)]:mb-4">
+        <h2 className="text-xl font-bold leading-tight text-[#0A1128]">Complete seu perfil</h2>
+        <p className="mt-2 max-w-[440px] text-xs leading-5 text-[#0A1128]/65">
+          para continuar preencha o formulário — Acesso para professores
+        </p>
+      </div>
+
+      <form
+        aria-label="register professor form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (step < 2) {
+            goToNextStep();
+            return;
+          }
+          void handleSubmit();
+        }}
+        noValidate
+        className="flex flex-col gap-4 [@media(max-height:760px)]:gap-3"
+      >
+        {step === 1 ? (
+          <>
+            <TextField
+              label="Nome Completo"
+              name="fullName"
+              value={values.fullName}
+              onBlur={markTouchedAndValidate}
+              onChange={handleTextChange}
+              error={errors.fullName}
+            />
+            <TextField
+              label="Email Institucional"
+              name="email"
+              value={values.email}
+              type="email"
+              onBlur={markTouchedAndValidate}
+              onChange={handleTextChange}
+              error={errors.email}
+            />
+            <TextField
+              label="Senha"
+              name="password"
+              value={values.password}
+              type="password"
+              onBlur={markTouchedAndValidate}
+              onChange={handleTextChange}
+              error={errors.password}
+            />
+            <TextField
+              label="Confirmação de senha"
+              name="confirmPassword"
+              value={values.confirmPassword}
+              type="password"
+              onBlur={markTouchedAndValidate}
+              onChange={handleTextChange}
+              error={errors.confirmPassword}
+            />
+          </>
+        ) : null}
+
+        {step === 2 ? (
+          <>
+            <LockedInstitutionField value={values.institution} error={errors.institution} />
+            <TextField
+              label="SIAPE"
+              name="siape"
+              value={values.siape}
+              inputMode="numeric"
+              maxLength={7}
+              onBlur={markTouchedAndValidate}
+              onChange={(field, value) => handleTextChange(field, value.replace(/\D/g, ''))}
+              error={errors.siape}
+            />
+            <TextField
+              label="Departamento"
+              name="department"
+              value={values.department}
+              onBlur={markTouchedAndValidate}
+              onChange={handleTextChange}
+              error={errors.department}
+            />
+            <TextField
+              label="Curso"
+              name="course"
+              value={values.course}
+              onBlur={markTouchedAndValidate}
+              onChange={handleTextChange}
+              error={errors.course}
+            />
+          </>
+        ) : null}
+
+        {formError ? <span className="text-xs font-medium text-red-500">{formError}</span> : null}
+
+        {step > 1 ? (
+          <button
+            type="button"
+            onClick={goToPreviousStep}
+            className="h-10 w-full cursor-pointer rounded-[7px] border border-[#14D5C2] bg-white px-4 text-sm font-bold text-[#0A1128] transition-colors hover:bg-[#E8FAF8]"
+          >
+            Voltar etapa
+          </button>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={!isCurrentStepValid}
+          className="mt-1 h-10 w-full cursor-pointer rounded-[7px] bg-[#14D5C2] px-4 text-sm font-bold text-[#0A1128] transition-colors hover:brightness-95 disabled:cursor-not-allowed disabled:bg-[#9FE7DF] disabled:text-[#0A1128]/55"
+        >
+          {isLoading ? 'Finalizando...' : 'Completar cadastro'}
+        </button>
+
+        <Link
+          to="/professor/login"
+          className="mt-3 inline-flex items-center justify-center gap-1.5 text-sm font-bold text-[#00AFA0] transition-colors hover:text-[#0A1128]"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Voltar para o login
+        </Link>
+      </form>
+    </section>
+  );
+};

--- a/src/features/register-professor/ui/RegisterProfessorForm.tsx
+++ b/src/features/register-professor/ui/RegisterProfessorForm.tsx
@@ -32,7 +32,7 @@ const INPUT_CLASS =
   'h-10 w-full rounded-[7px] border px-3.5 text-sm text-[#0A1128] outline-none transition-colors ' +
   'placeholder:text-[#0A1128]/45 focus:border-[#14D5C2] bg-white';
 
-const EMAIL_UNB_REGEX = /^[^\s@]+@unb\.br$/i;
+const EMAIL_UNB_REGEX = /^[^\s@]+@(?:[a-z0-9-]+\.)*unb\.br$/i;
 const SIAPE_REGEX = /^\d{7}$/;
 
 type TextFieldProps = {
@@ -127,7 +127,7 @@ const validateField = (
     case 'email':
       if (!trimmedValue) return 'Email institucional é obrigatório.';
       if (!EMAIL_UNB_REGEX.test(trimmedValue)) {
-        return 'Use um email institucional @unb.br.';
+        return 'Use um email institucional UnB.';
       }
       return undefined;
     case 'password':

--- a/src/pages/professor-register/index.ts
+++ b/src/pages/professor-register/index.ts
@@ -1,0 +1,1 @@
+export { ProfessorRegisterPage } from './ui/ProfessorRegisterPage';

--- a/src/pages/professor-register/ui/ProfessorRegisterPage.test.tsx
+++ b/src/pages/professor-register/ui/ProfessorRegisterPage.test.tsx
@@ -1,0 +1,20 @@
+jest.mock('../../../features/register-professor', () => ({
+  RegisterProfessorForm: () => <form aria-label="register professor form" />,
+}));
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProfessorRegisterPage } from './ProfessorRegisterPage';
+
+describe('ProfessorRegisterPage', () => {
+  it('renderiza logo e formulario de cadastro do professor', () => {
+    render(
+      <MemoryRouter>
+        <ProfessorRegisterPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByAltText(/Logo AnatoQuizUp/i)).toBeInTheDocument();
+    expect(screen.getByRole('form', { name: /register professor form/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/professor-register/ui/ProfessorRegisterPage.tsx
+++ b/src/pages/professor-register/ui/ProfessorRegisterPage.tsx
@@ -1,0 +1,31 @@
+import { RegisterProfessorForm } from '../../../features/register-professor';
+import mascotImg from '../../../shared/assets/image/logo.png';
+
+export const ProfessorRegisterPage = () => {
+  return (
+    <main className="relative min-h-screen w-full overflow-x-hidden bg-[#F7F7F7]">
+      <div className="absolute inset-y-0 left-0 hidden w-[57vw] bg-[#00214d] [clip-path:polygon(0_0,40%_0,100%_100%,0_100%)] md:block [@media(min-width:768px)_and_(max-width:1100px)]:w-[50vw] [@media(min-width:768px)_and_(max-height:760px)]:w-[52vw] [@media(min-width:768px)_and_(max-width:1100px)]:[clip-path:polygon(0_0,34%_0,100%_100%,0_100%)]"></div>
+
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-5 py-8 md:flex-row md:items-center md:justify-between md:px-8 md:py-8 lg:px-16 xl:px-20 [@media(min-width:768px)_and_(max-height:760px)]:items-start [@media(min-width:768px)_and_(max-height:760px)]:py-5">
+        <section className="mb-10 w-full md:sticky md:top-0 md:mb-0 md:flex md:h-[calc(100vh-4rem)] md:w-[50%] md:items-center md:justify-start lg:w-[51%] [@media(min-width:768px)_and_(max-height:760px)]:h-[calc(100vh-2.5rem)]">
+          <div className="mb-16 md:hidden">
+            <h1 className="text-4xl font-bold text-[#0A1128]">Cadastro</h1>
+            <span className="mt-2 block h-1 w-32 rounded bg-[#0A1128]"></span>
+          </div>
+
+          <div className="flex w-full justify-center md:justify-start">
+            <img
+              src={mascotImg}
+              alt="Logo AnatoQuizUp"
+              className="h-auto w-full max-w-[260px] md:max-w-[290px] lg:max-w-[370px] xl:max-w-[410px] [@media(min-width:768px)_and_(max-height:760px)]:max-w-[300px]"
+            />
+          </div>
+        </section>
+
+        <section className="flex w-full justify-center md:h-[calc(100vh-4rem)] md:w-[50%] md:items-center md:justify-end lg:w-[49%] [@media(min-width:768px)_and_(max-height:760px)]:h-[calc(100vh-2.5rem)]">
+          <RegisterProfessorForm />
+        </section>
+      </div>
+    </main>
+  );
+};

--- a/src/pages/professor-register/ui/ProfessorRegisterPage.tsx
+++ b/src/pages/professor-register/ui/ProfessorRegisterPage.tsx
@@ -1,16 +1,36 @@
 import { RegisterProfessorForm } from '../../../features/register-professor';
 import mascotImg from '../../../shared/assets/image/logo.png';
 
+const pageClassName = 'relative min-h-screen w-full overflow-x-hidden bg-[#F7F7F7]';
+const backgroundShapeClassName =
+  'absolute inset-y-0 left-0 hidden w-[57vw] bg-[#00214d] md:block ' +
+  '[clip-path:polygon(0_0,40%_0,100%_100%,0_100%)] ' +
+  '[@media(min-width:768px)_and_(max-width:1100px)]:w-[50vw] ' +
+  '[@media(min-width:768px)_and_(max-height:760px)]:w-[52vw] ' +
+  '[@media(min-width:768px)_and_(max-width:1100px)]:[clip-path:polygon(0_0,34%_0,100%_100%,0_100%)]';
+const contentClassName =
+  'relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-5 py-8 ' +
+  'md:flex-row md:items-center md:justify-between md:px-8 md:py-8 lg:px-16 xl:px-20 ' +
+  '[@media(min-width:768px)_and_(max-height:760px)]:items-start ' +
+  '[@media(min-width:768px)_and_(max-height:760px)]:py-5';
+const brandSectionClassName =
+  'mb-10 w-full md:sticky md:top-0 md:mb-0 md:flex md:h-[calc(100vh-4rem)] ' +
+  'md:w-[50%] md:items-center md:justify-start lg:w-[51%] ' +
+  '[@media(min-width:768px)_and_(max-height:760px)]:h-[calc(100vh-2.5rem)]';
+const formSectionClassName =
+  'flex w-full justify-center md:h-[calc(100vh-4rem)] md:w-[50%] md:items-center ' +
+  'md:justify-end lg:w-[49%] [@media(min-width:768px)_and_(max-height:760px)]:h-[calc(100vh-2.5rem)]';
+
 export const ProfessorRegisterPage = () => {
   return (
-    <main className="relative min-h-screen w-full overflow-x-hidden bg-[#F7F7F7]">
-      <div className="absolute inset-y-0 left-0 hidden w-[57vw] bg-[#00214d] [clip-path:polygon(0_0,40%_0,100%_100%,0_100%)] md:block [@media(min-width:768px)_and_(max-width:1100px)]:w-[50vw] [@media(min-width:768px)_and_(max-height:760px)]:w-[52vw] [@media(min-width:768px)_and_(max-width:1100px)]:[clip-path:polygon(0_0,34%_0,100%_100%,0_100%)]"></div>
+    <main className={pageClassName}>
+      <div className={backgroundShapeClassName} />
 
-      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-5 py-8 md:flex-row md:items-center md:justify-between md:px-8 md:py-8 lg:px-16 xl:px-20 [@media(min-width:768px)_and_(max-height:760px)]:items-start [@media(min-width:768px)_and_(max-height:760px)]:py-5">
-        <section className="mb-10 w-full md:sticky md:top-0 md:mb-0 md:flex md:h-[calc(100vh-4rem)] md:w-[50%] md:items-center md:justify-start lg:w-[51%] [@media(min-width:768px)_and_(max-height:760px)]:h-[calc(100vh-2.5rem)]">
+      <div className={contentClassName}>
+        <section className={brandSectionClassName}>
           <div className="mb-16 md:hidden">
             <h1 className="text-4xl font-bold text-[#0A1128]">Cadastro</h1>
-            <span className="mt-2 block h-1 w-32 rounded bg-[#0A1128]"></span>
+            <span className="mt-2 block h-1 w-32 rounded bg-[#0A1128]" />
           </div>
 
           <div className="flex w-full justify-center md:justify-start">
@@ -22,7 +42,7 @@ export const ProfessorRegisterPage = () => {
           </div>
         </section>
 
-        <section className="flex w-full justify-center md:h-[calc(100vh-4rem)] md:w-[50%] md:items-center md:justify-end lg:w-[49%] [@media(min-width:768px)_and_(max-height:760px)]:h-[calc(100vh-2.5rem)]">
+        <section className={formSectionClassName}>
           <RegisterProfessorForm />
         </section>
       </div>


### PR DESCRIPTION
## Descrição

Implementa a interface de cadastro de professor no Frontend e integra o fluxo à arquitetura atual com BFF.

Nesta branch foi adicionada a página `/professor/cadastro`, com a feature `register-professor`, formulário de cadastro, validações client-side, tela de confirmação pós-cadastro e tratamento de erros inline vindos da API.

O formulário contempla os campos exigidos para cadastro docente: nome completo, email institucional, senha, confirmação de senha, SIAPE, instituição bloqueada, departamento e curso. A instituição é exibida como `Universidade de Brasília — UnB`, mas enviada para a API como `UnB`, conforme contrato definido para o Backend.

Também foram implementadas validações client-side para:
- email institucional UnB, incluindo subdomínios como `medicina.unb.br`;
- SIAPE com exatamente 7 dígitos numéricos;
- senha com no mínimo 8 caracteres;
- confirmação de senha igual à senha;
- campos obrigatórios preenchidos.

A chamada de API foi alinhada à arquitetura BFF, usando o `httpClient` existente e o endpoint:

`POST /autenticacao/cadastro/professor`

Este PR é o PR principal do fluxo e depende dos PRs complementares no [BFF ](https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-BFF/pull/6) e no [Backend ](https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-Backend/pull/111) para funcionamento ponta a ponta.

No BFF, foi liberada a rota pública `/api/v1/autenticacao/cadastro/professor`.

No Backend, foi implementado o cadastro de professor com validação Zod, verificação de email/SIAPE duplicados, hash de senha com bcrypt, criação de usuário com perfil `PROFESSOR` e status `PENDENTE`.

## Rastreabilidade

Issue(s) Relacionada(s):

https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-Backend/issues/17
https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-Web/issues/12

Commits relacionados:

Frontend:
- [feat(cadastro-professor): adiciona servico de cadastro](https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-Web/pull/49/changes/213773b63e9966596840f977d00c67141fcd93b5)
- [feat(cadastro-professor): implementa formulario de cadastro](https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-Web/pull/49/changes/fc8454f26f6d8d3f79be056225b399ebb94ea498)
- [feat(cadastro-professor): adiciona rota de cadastro](https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-Web/pull/49/changes/af975426c4efc54f972868e58d1b157b558a3cf4)

BFF:
- [feat: libera cadastro de professor no bff](https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-BFF/pull/6/changes/5e9b46ed51b15b14f62d701235015bc629c58876)

Backend:
- [feat: adiciona cadastro de professor](https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-Backend/pull/111/changes/ba0d98c448fceec9df14907f5b2cc2b5ef6346ca)
- [test: cobre cadastro de professor](https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-Backend/pull/111/changes/dbe908acc6b50ebdc2c46ae6480cb102bbebfb0b)
- [test: amplia cobertura do cadastro de professor](https://github.com/fga-eps-mds/2026-1-AnatoQuizUp-Backend/pull/111/changes/0e32cff5f8e3c1d22e01e1b98a5b3078511fc07f)

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [x] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Evidências (se aplicável)

Validações executadas localmente:

Frontend:
- `npm run lint`
- `npm test -- RegisterProfessorForm.test.tsx registerProfessorService.test.ts --runInBand`
- `npm run build`

BFF:
- `npm run lint`
- `npm test -- auth.routes.test.ts --runInBand`
- `npm run build`

Backend:
- `npm run lint`
- `npm test -- --coverage --runInBand`
- `npm run build`

Resultado backend:
- 41 suítes passaram
- 273 testes passaram
- Cobertura global acima de 95%

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

A rota `/professor/login` não foi alterada neste PR, pois pertence a outra frente de trabalho.

O contrato de integração segue a PRD de migração BFF, que é a fonte de verdade arquitetural atual. Por isso, o Frontend chama `/autenticacao/cadastro/professor` via BFF, em vez do path antigo descrito no card original.
