### PR TITLE
Feat/turma

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -2,9 +2,19 @@ import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { App } from './App';
 
+jest.mock('../shared/config/env', () => ({
+  env: {
+    VITE_API_URL: 'http://localhost:3333',
+  },
+}));
+
 jest.mock('./providers/AuthProvider', () => ({
   AuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
-  useAuth:jest.fn(),
+  useAuth: jest.fn().mockReturnValue({
+    isAuthenticated: true,
+    isLoading: false,
+    user: { role: 'PROFESSOR' }, 
+  }),
 }));
 
 jest.mock('./layouts/AuthenticatedLayout', () => {
@@ -59,6 +69,10 @@ jest.mock('../pages/professor/criar-questao', () => ({
   CreateQuestionPage: () => <main>Create question route</main>,
 }));
 
+jest.mock('../pages/turma/ui/TurmaPage', () => ({
+  TurmasPage: () => <main>Turmas route</main>,
+}));
+
 const renderAppAt = (path: string) => {
   window.history.pushState({}, '', path);
   return render(<App />);
@@ -71,37 +85,36 @@ describe('App', () => {
 
   it('renders the login route', () => {
     renderAppAt('/login');
-
     expect(screen.getByText('Login route')).toBeInTheDocument();
   });
 
   it('renders the register route', () => {
     renderAppAt('/cadastro');
-
     expect(screen.getByText('Register route')).toBeInTheDocument();
   });
 
   it('renders the professor register route', () => {
     renderAppAt('/professor/cadastro');
-
     expect(screen.getByText('Professor register route')).toBeInTheDocument();
   });
 
   it('renders the forgot password route', () => {
     renderAppAt('/esqueci-senha');
-
     expect(screen.getByText('Forgot password route')).toBeInTheDocument();
   });
 
   it('renders the reset password route', () => {
     renderAppAt('/redefinir-senha?token=token');
-
     expect(screen.getByText('Reset password route')).toBeInTheDocument();
+  });
+
+  it('renders the turmas route', () => {
+    renderAppAt('/turmas');
+    expect(screen.getByText('Turmas route')).toBeInTheDocument();
   });
 
   it('redirects unknown routes to the public home route', () => {
     renderAppAt('/unknown');
-
     expect(screen.getByText('Home route')).toBeInTheDocument();
   });
 });

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -11,6 +11,7 @@ import { ProtectedRoute } from "./router/ProtectedRoute";
 import { HomeProfessorPage } from "../pages/homeProfessor";
 import { QuestionsPage } from "../pages/questao";
 import { CreateQuestionPage } from "../pages/professor/criar-questao";
+import { TurmasPage } from "../pages/turma/ui/TurmaPage";
 
 export const AppRouter = () => {
   return (
@@ -48,6 +49,7 @@ export const AppRouter = () => {
             </ProtectedRoute>
           } 
         />
+
         <Route
           path="/professor/questoes"
           element={
@@ -56,6 +58,7 @@ export const AppRouter = () => {
             </ProtectedRoute>
           }
         />
+        
         <Route
           path="/professor/criar-questao"
           element={
@@ -64,6 +67,16 @@ export const AppRouter = () => {
             </ProtectedRoute>
           }
         />
+
+        <Route
+          path="/turmas"
+          element={
+            <ProtectedRoute allowedRoles={['PROFESSOR', 'ADMIN']}>
+              <TurmasPage />
+            </ProtectedRoute>
+          }
+        />
+        
       </Route>
 
       <Route path="*" element={<Navigate to="/home" replace />} />

--- a/src/entities/turmas/api/trumaApi.test.ts
+++ b/src/entities/turmas/api/trumaApi.test.ts
@@ -1,0 +1,71 @@
+import { httpClient } from '../../../shared/api/httpClient';
+import { listarTurmas, excluirTurma } from './turmaApi'; 
+import type { Turma } from '../model/types';
+
+jest.mock('../../../shared/api/httpClient', () => ({
+  httpClient: {
+    get: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+describe('turmaApi', () => {
+  const mockTurmas: Turma[] = [
+    {
+      id: 'turma-1',
+      codigo: 'ANAT-01',
+      nome: 'Anatomia Sistêmica',
+      semestre: '1',
+      ano: 2026,
+      descricao: 'Turma de teste',
+      status: 'ATIVA',
+      quantidadeAlunos: 20,
+      criadoEm: '2026-05-16T10:00:00.000Z',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listarTurmas', () => {
+    it('deve fazer um GET para /turmas e retornar apenas o array de dados', async () => {
+      (httpClient.get as jest.Mock).mockResolvedValue({
+        data: {
+          mensagem: 'Turmas listadas com sucesso',
+          dados: mockTurmas,
+        },
+      });
+
+      const resultado = await listarTurmas();
+
+      expect(httpClient.get).toHaveBeenCalledWith('/turmas', { params: undefined });
+      
+      expect(resultado).toEqual(mockTurmas);
+    });
+
+    it('deve repassar os filtros (busca e status) como query params', async () => {
+      (httpClient.get as jest.Mock).mockResolvedValue({
+        data: { mensagem: 'OK', dados: [] },
+      });
+
+      const filtros = { busca: 'Neuro', status: 'INATIVA' as const };
+      
+      await listarTurmas(filtros);
+
+      expect(httpClient.get).toHaveBeenCalledWith('/turmas', {
+        params: { busca: 'Neuro', status: 'INATIVA' },
+      });
+    });
+  });
+
+  describe('excluirTurma', () => {
+    it('deve fazer um DELETE para a rota de turmas passando o ID na URL', async () => {
+      (httpClient.delete as jest.Mock).mockResolvedValue({});
+
+      await excluirTurma('turma-123');
+
+      expect(httpClient.delete).toHaveBeenCalledWith('/turmas/turma-123');
+    });
+  });
+});

--- a/src/entities/turmas/api/trumaApi.test.ts
+++ b/src/entities/turmas/api/trumaApi.test.ts
@@ -1,71 +1,163 @@
 import { httpClient } from '../../../shared/api/httpClient';
-import { listarTurmas, excluirTurma } from './turmaApi'; 
-import type { Turma } from '../model/types';
+import {
+  atualizarTurma,
+  criarTurma,
+  desvincularAlunoTurma,
+  excluirTurma,
+  listarAlunosDaTurma,
+  listarTurmas,
+  vincularAlunoTurma,
+} from './turmaApi';
 
 jest.mock('../../../shared/api/httpClient', () => ({
   httpClient: {
     get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
     delete: jest.fn(),
   },
 }));
 
 describe('turmaApi', () => {
-  const mockTurmas: Turma[] = [
-    {
-      id: 'turma-1',
-      codigo: 'ANAT-01',
-      nome: 'Anatomia Sistêmica',
-      semestre: '1',
-      ano: 2026,
-      descricao: 'Turma de teste',
-      status: 'ATIVA',
-      quantidadeAlunos: 20,
-      criadoEm: '2026-05-16T10:00:00.000Z',
+  const turmaApi = {
+    id: 'turma-1',
+    codigo: 'ANAT-01',
+    nome: 'Anatomia Sistemica',
+    semestre: '1',
+    ano: 2026,
+    descricao: 'Turma de teste',
+    status: 'ATIVA' as const,
+    criadoEm: '2026-05-16T10:00:00.000Z',
+    _count: {
+      alunos: 20,
     },
-  ];
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('listarTurmas', () => {
-    it('deve fazer um GET para /turmas e retornar apenas o array de dados', async () => {
+    it('deve fazer GET para /turmas e normalizar a contagem de alunos', async () => {
       (httpClient.get as jest.Mock).mockResolvedValue({
         data: {
           mensagem: 'Turmas listadas com sucesso',
-          dados: mockTurmas,
+          dados: [turmaApi],
         },
       });
 
       const resultado = await listarTurmas();
 
       expect(httpClient.get).toHaveBeenCalledWith('/turmas', { params: undefined });
-      
-      expect(resultado).toEqual(mockTurmas);
+      expect(resultado).toEqual([
+        {
+          id: 'turma-1',
+          codigo: 'ANAT-01',
+          nome: 'Anatomia Sistemica',
+          semestre: '1',
+          ano: 2026,
+          descricao: 'Turma de teste',
+          status: 'ATIVA',
+          criadoEm: '2026-05-16T10:00:00.000Z',
+          quantidadeAlunos: 20,
+        },
+      ]);
     });
 
-    it('deve repassar os filtros (busca e status) como query params', async () => {
+    it('deve repassar os filtros como query params', async () => {
       (httpClient.get as jest.Mock).mockResolvedValue({
         data: { mensagem: 'OK', dados: [] },
       });
 
-      const filtros = { busca: 'Neuro', status: 'INATIVA' as const };
-      
-      await listarTurmas(filtros);
+      await listarTurmas({
+        busca: 'Neuro',
+        status: 'INATIVA',
+        semestre: '2',
+        ano: 2025,
+      });
 
       expect(httpClient.get).toHaveBeenCalledWith('/turmas', {
-        params: { busca: 'Neuro', status: 'INATIVA' },
+        params: {
+          busca: 'Neuro',
+          status: 'INATIVA',
+          semestre: '2',
+          ano: 2025,
+        },
       });
     });
   });
 
-  describe('excluirTurma', () => {
-    it('deve fazer um DELETE para a rota de turmas passando o ID na URL', async () => {
-      (httpClient.delete as jest.Mock).mockResolvedValue({});
+  it('deve criar uma turma', async () => {
+    const payload = {
+      codigo: 'ANAT-01',
+      nome: 'Anatomia Sistemica',
+      semestre: '1',
+      ano: 2026,
+      descricao: 'Turma de teste',
+      status: 'ATIVA' as const,
+    };
 
-      await excluirTurma('turma-123');
-
-      expect(httpClient.delete).toHaveBeenCalledWith('/turmas/turma-123');
+    (httpClient.post as jest.Mock).mockResolvedValue({
+      data: { mensagem: 'Criada', dados: turmaApi },
     });
+
+    const resultado = await criarTurma(payload);
+
+    expect(httpClient.post).toHaveBeenCalledWith('/turmas', payload);
+    expect(resultado.quantidadeAlunos).toBe(20);
+  });
+
+  it('deve atualizar uma turma', async () => {
+    const payload = { nome: 'Neuroanatomia' };
+    (httpClient.patch as jest.Mock).mockResolvedValue({
+      data: { mensagem: 'Atualizada', dados: { ...turmaApi, nome: 'Neuroanatomia' } },
+    });
+
+    const resultado = await atualizarTurma('turma-1', payload);
+
+    expect(httpClient.patch).toHaveBeenCalledWith('/turmas/turma-1', payload);
+    expect(resultado.nome).toBe('Neuroanatomia');
+  });
+
+  it('deve excluir uma turma', async () => {
+    (httpClient.delete as jest.Mock).mockResolvedValue({});
+
+    await excluirTurma('turma-123');
+
+    expect(httpClient.delete).toHaveBeenCalledWith('/turmas/turma-123');
+  });
+
+  it('deve listar vinculos de alunos da turma', async () => {
+    const vinculos = [{ id: 'vinculo-1', turmaId: 'turma-1', alunoId: 'aluno-1' }];
+    (httpClient.get as jest.Mock).mockResolvedValue({
+      data: { mensagem: 'OK', dados: vinculos },
+    });
+
+    const resultado = await listarAlunosDaTurma('turma-1');
+
+    expect(httpClient.get).toHaveBeenCalledWith('/turmas/turma-1/alunos');
+    expect(resultado).toBe(vinculos);
+  });
+
+  it('deve vincular aluno a turma', async () => {
+    const vinculo = { id: 'vinculo-1', turmaId: 'turma-1', alunoId: 'aluno-1' };
+    (httpClient.post as jest.Mock).mockResolvedValue({
+      data: { mensagem: 'OK', dados: vinculo },
+    });
+
+    const resultado = await vincularAlunoTurma('turma-1', 'aluno-1');
+
+    expect(httpClient.post).toHaveBeenCalledWith('/turmas/turma-1/alunos', {
+      alunoId: 'aluno-1',
+    });
+    expect(resultado).toBe(vinculo);
+  });
+
+  it('deve desvincular aluno da turma', async () => {
+    (httpClient.delete as jest.Mock).mockResolvedValue({});
+
+    await desvincularAlunoTurma('turma-1', 'aluno-1');
+
+    expect(httpClient.delete).toHaveBeenCalledWith('/turmas/turma-1/alunos/aluno-1');
   });
 });

--- a/src/entities/turmas/api/turmaApi.ts
+++ b/src/entities/turmas/api/turmaApi.ts
@@ -1,18 +1,66 @@
 import { httpClient } from '../../../shared/api/httpClient';
-import type { Turma, StatusTurma } from '../model/types';
+import type {
+  AtualizarTurmaPayload,
+  FiltrosTurma,
+  SalvarTurmaPayload,
+  Turma,
+  VinculoTurmaAluno,
+} from '../model/types';
 
-interface FiltrosTurma {
-  busca?: string;
-  status?: StatusTurma;
-}
+type RespostaApi<T> = {
+  mensagem?: string;
+  dados: T;
+};
+
+type TurmaApi = Omit<Turma, 'quantidadeAlunos'> & {
+  quantidadeAlunos?: number;
+  _count?: {
+    alunos?: number;
+  };
+};
+
+const normalizarTurma = (turma: TurmaApi): Turma => {
+  const { _count, quantidadeAlunos, ...dadosTurma } = turma;
+
+  return {
+    ...dadosTurma,
+    quantidadeAlunos: quantidadeAlunos ?? _count?.alunos ?? 0,
+  };
+};
 
 export const listarTurmas = async (filtros?: FiltrosTurma) => {
-  const response = await httpClient.get<{ mensagem: string; dados: Turma[] }>('/turmas', {
+  const response = await httpClient.get<RespostaApi<TurmaApi[]>>('/turmas', {
     params: filtros,
   });
-  return response.data.dados;
+  return response.data.dados.map(normalizarTurma);
+};
+
+export const criarTurma = async (payload: SalvarTurmaPayload) => {
+  const response = await httpClient.post<RespostaApi<TurmaApi>>('/turmas', payload);
+  return normalizarTurma(response.data.dados);
+};
+
+export const atualizarTurma = async (id: string, payload: AtualizarTurmaPayload) => {
+  const response = await httpClient.patch<RespostaApi<TurmaApi>>(`/turmas/${id}`, payload);
+  return normalizarTurma(response.data.dados);
 };
 
 export const excluirTurma = async (id: string) => {
   await httpClient.delete(`/turmas/${id}`);
+};
+
+export const listarAlunosDaTurma = async (turmaId: string) => {
+  const response = await httpClient.get<RespostaApi<VinculoTurmaAluno[]>>(`/turmas/${turmaId}/alunos`);
+  return response.data.dados;
+};
+
+export const vincularAlunoTurma = async (turmaId: string, alunoId: string) => {
+  const response = await httpClient.post<RespostaApi<VinculoTurmaAluno>>(`/turmas/${turmaId}/alunos`, {
+    alunoId,
+  });
+  return response.data.dados;
+};
+
+export const desvincularAlunoTurma = async (turmaId: string, alunoId: string) => {
+  await httpClient.delete(`/turmas/${turmaId}/alunos/${alunoId}`);
 };

--- a/src/entities/turmas/api/turmaApi.ts
+++ b/src/entities/turmas/api/turmaApi.ts
@@ -1,0 +1,18 @@
+import { httpClient } from '../../../shared/api/httpClient';
+import type { Turma, StatusTurma } from '../model/types';
+
+interface FiltrosTurma {
+  busca?: string;
+  status?: StatusTurma;
+}
+
+export const listarTurmas = async (filtros?: FiltrosTurma) => {
+  const response = await httpClient.get<{ mensagem: string; dados: Turma[] }>('/turmas', {
+    params: filtros,
+  });
+  return response.data.dados;
+};
+
+export const excluirTurma = async (id: string) => {
+  await httpClient.delete(`/turmas/${id}`);
+};

--- a/src/entities/turmas/model/types.ts
+++ b/src/entities/turmas/model/types.ts
@@ -1,0 +1,13 @@
+export type StatusTurma = 'ATIVA' | 'INATIVA';
+
+export interface Turma {
+  id: string;
+  codigo: string;
+  nome: string;
+  semestre: string;
+  ano: number;
+  descricao: string;
+  status: StatusTurma;
+  quantidadeAlunos: number;
+  criadoEm: string; 
+}

--- a/src/entities/turmas/model/types.ts
+++ b/src/entities/turmas/model/types.ts
@@ -11,3 +11,29 @@ export interface Turma {
   quantidadeAlunos: number;
   criadoEm: string; 
 }
+
+export interface FiltrosTurma {
+  busca?: string;
+  status?: StatusTurma;
+  semestre?: string;
+  ano?: number;
+}
+
+export interface SalvarTurmaPayload {
+  codigo: string;
+  nome: string;
+  semestre: string;
+  ano: number;
+  descricao: string;
+  status?: StatusTurma;
+}
+
+export type AtualizarTurmaPayload = Partial<SalvarTurmaPayload>;
+
+export interface VinculoTurmaAluno {
+  id: string;
+  turmaId: string;
+  alunoId: string;
+  criadoEm: string;
+  atualizadoEm: string;
+}

--- a/src/entities/usuarios/api/usuarioApi.test.ts
+++ b/src/entities/usuarios/api/usuarioApi.test.ts
@@ -1,0 +1,61 @@
+import { httpClient } from '../../../shared/api/httpClient';
+import { buscarAlunos, buscarUsuariosPorIds } from './usuarioApi';
+
+jest.mock('../../../shared/api/httpClient', () => ({
+  httpClient: {
+    get: jest.fn(),
+  },
+}));
+
+describe('usuarioApi', () => {
+  const aluno = {
+    id: 'aluno-1',
+    nome: 'Joao Silva',
+    nickname: 'joao',
+    email: 'joao@example.com',
+    perfil: 'ALUNO',
+    status: 'ATIVO',
+    instituicao: 'UnB',
+    curso: 'Medicina',
+    semestre: '2026.1',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve buscar alunos por texto', async () => {
+    const resposta = {
+      dados: [aluno],
+      metadados: { page: 1, limit: 10, total: 1, totalPages: 1 },
+    };
+    (httpClient.get as jest.Mock).mockResolvedValue({ data: resposta });
+
+    const resultado = await buscarAlunos({ busca: 'joao', limit: 10 });
+
+    expect(httpClient.get).toHaveBeenCalledWith('/usuarios/alunos', {
+      params: { busca: 'joao', limit: 10 },
+    });
+    expect(resultado).toBe(resposta);
+  });
+
+  it('deve buscar usuarios por ids', async () => {
+    (httpClient.get as jest.Mock).mockResolvedValue({
+      data: { mensagem: 'Usuarios encontrados', dados: [aluno] },
+    });
+
+    const resultado = await buscarUsuariosPorIds(['aluno-1', 'aluno-2']);
+
+    expect(httpClient.get).toHaveBeenCalledWith('/usuarios', {
+      params: { ids: 'aluno-1,aluno-2' },
+    });
+    expect(resultado).toEqual([aluno]);
+  });
+
+  it('deve evitar chamada quando a lista de ids estiver vazia', async () => {
+    const resultado = await buscarUsuariosPorIds([]);
+
+    expect(httpClient.get).not.toHaveBeenCalled();
+    expect(resultado).toEqual([]);
+  });
+});

--- a/src/entities/usuarios/api/usuarioApi.ts
+++ b/src/entities/usuarios/api/usuarioApi.ts
@@ -1,0 +1,34 @@
+import { httpClient } from '../../../shared/api/httpClient';
+import type { ResultadoBuscaAlunos, UsuarioResumo } from '../model/types';
+
+type RespostaApi<T> = {
+  mensagem?: string;
+  dados: T;
+};
+
+interface BuscarAlunosParams {
+  busca?: string;
+  page?: number;
+  limit?: number;
+}
+
+export const buscarAlunos = async (params?: BuscarAlunosParams) => {
+  const response = await httpClient.get<ResultadoBuscaAlunos>('/usuarios/alunos', {
+    params,
+  });
+  return response.data;
+};
+
+export const buscarUsuariosPorIds = async (ids: string[]) => {
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const response = await httpClient.get<RespostaApi<UsuarioResumo[]>>('/usuarios', {
+    params: {
+      ids: ids.join(','),
+    },
+  });
+
+  return response.data.dados;
+};

--- a/src/entities/usuarios/model/types.ts
+++ b/src/entities/usuarios/model/types.ts
@@ -1,0 +1,26 @@
+export type PerfilUsuario = 'ALUNO' | 'PROFESSOR' | 'ADMINISTRADOR';
+export type StatusUsuario = 'ATIVO' | 'INATIVO';
+
+export interface UsuarioResumo {
+  id: string;
+  nome: string;
+  nickname: string | null;
+  email: string;
+  perfil: PerfilUsuario;
+  status: StatusUsuario;
+  instituicao: string | null;
+  curso: string | null;
+  semestre: string | null;
+}
+
+export interface MetadadosPaginacao {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface ResultadoBuscaAlunos {
+  dados: UsuarioResumo[];
+  metadados: MetadadosPaginacao;
+}

--- a/src/features/manage-turmas/ui/ListarTurmas.test.tsx
+++ b/src/features/manage-turmas/ui/ListarTurmas.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ListaTurmas } from './ListarTurmas';
+import { listarTurmas, excluirTurma } from '../../../entities/turmas/api/turmaApi';
+import type { Turma } from '../../../entities/turmas/model/types';
+
+jest.mock('../../../entities/turmas/api/turmaApi', () => ({
+  listarTurmas: jest.fn(),
+  excluirTurma: jest.fn(),
+}));
+
+jest.mock('./ModalExcluirTurma', () => ({
+  ModalExcluirTurma: ({ 
+    isOpen, 
+    onClose, 
+    onConfirm, 
+    turma 
+  }: { 
+    isOpen: boolean; 
+    onClose: () => void; 
+    onConfirm: () => void; 
+    turma: Turma | null; 
+  }) => {
+    if (!isOpen) return null;
+    return (
+      <div data-testid="mock-modal">
+        <span data-testid="modal-turma-nome">{turma?.nome}</span>
+        <button onClick={onClose} data-testid="modal-btn-cancelar">Cancelar</button>
+        <button onClick={onConfirm} data-testid="modal-btn-confirmar">Confirmar Exclusão</button>
+      </div>
+    );
+  },
+}));
+
+const mockTurmas: Turma[] = [
+  {
+    id: 'turma-1',
+    codigo: 'ANAT-01',
+    nome: 'Anatomia Sistêmica',
+    semestre: '1',
+    ano: 2026,
+    descricao: 'Turma matutina',
+    status: 'ATIVA',
+    quantidadeAlunos: 15,
+    criadoEm: '2026-05-14T10:00:00.000Z',
+  },
+  {
+    id: 'turma-2',
+    codigo: 'NEURO-02',
+    nome: 'Neuroanatomia',
+    semestre: '2',
+    ano: 2025,
+    descricao: 'Turma noturna',
+    status: 'INATIVA',
+    quantidadeAlunos: 30,
+    criadoEm: '2025-08-10T10:00:00.000Z',
+  },
+];
+
+describe('ListaTurmas Feature', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let windowAlertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    windowAlertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    windowAlertSpy.mockRestore();
+  });
+
+    it('deve carregar e renderizar a lista de turmas na montagem inicial', async () => {
+    (listarTurmas as jest.Mock).mockResolvedValue(mockTurmas);
+
+    render(<ListaTurmas />);
+
+    await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(1));
+    expect(listarTurmas).toHaveBeenCalledWith({ busca: undefined, status: undefined });
+
+    expect(await screen.findByText('Anatomia Sistêmica')).toBeInTheDocument();
+    
+    expect(screen.getByText('Neuroanatomia')).toBeInTheDocument();
+    expect(screen.getByText('2 turmas cadastradas')).toBeInTheDocument();
+  });
+
+  it('deve mostrar mensagem de lista vazia quando não houver turmas', async () => {
+    (listarTurmas as jest.Mock).mockResolvedValue([]);
+
+    render(<ListaTurmas />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Nenhuma turma encontrada.')).toBeInTheDocument();
+    });
+  });
+
+  it('deve lidar com erro na API ao carregar as turmas', async () => {
+    const erroMock = new Error('Falha na rede');
+    (listarTurmas as jest.Mock).mockRejectedValue(erroMock);
+
+    render(<ListaTurmas />);
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Erro ao carregar turmas', erroMock);
+    });
+  });
+
+  it('deve disparar nova busca ao digitar no campo de pesquisa', async () => {
+    const user = userEvent.setup();
+    (listarTurmas as jest.Mock).mockResolvedValue(mockTurmas);
+
+    render(<ListaTurmas />);
+
+    const inputBusca = screen.getByPlaceholderText('Buscar turma');
+    
+    await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(1));
+    jest.clearAllMocks();
+
+    await user.type(inputBusca, 'Anatomia');
+
+    await waitFor(() => {
+      expect(listarTurmas).toHaveBeenLastCalledWith(
+        expect.objectContaining({ busca: 'Anatomia' })
+      );
+    });
+  });
+
+  it('deve disparar nova busca ao alterar o filtro de status', async () => {
+    const user = userEvent.setup();
+    (listarTurmas as jest.Mock).mockResolvedValue(mockTurmas);
+
+    render(<ListaTurmas />);
+    await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(1));
+    jest.clearAllMocks();
+
+    const selectStatus = screen.getByDisplayValue('Todos os status');
+    await user.selectOptions(selectStatus, 'ATIVA');
+
+    await waitFor(() => {
+      expect(listarTurmas).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ATIVA' })
+      );
+    });
+  });
+
+  it('deve disparar os alerts nos botões de feature futura (Nova Turma e Editar)', async () => {
+    const user = userEvent.setup();
+    (listarTurmas as jest.Mock).mockResolvedValue([mockTurmas[0]]);
+
+    render(<ListaTurmas />);
+    await waitFor(() => expect(screen.getByText('Anatomia Sistêmica')).toBeInTheDocument());
+
+    const btnNovaTurma = screen.getByRole('button', { name: /Nova Turma/i });
+    await user.click(btnNovaTurma);
+    expect(windowAlertSpy).toHaveBeenCalledWith('Abrir feature de Nova Turma');
+
+    const btnEditar = screen.getByRole('button', { name: /Editar/i });
+    await user.click(btnEditar);
+    expect(windowAlertSpy).toHaveBeenCalledWith('Abrir edição para Anatomia Sistêmica');
+  });
+
+  describe('Fluxo de Exclusão (Modal)', () => {
+    it('deve abrir o modal ao clicar em excluir e permitir cancelar', async () => {
+      const user = userEvent.setup();
+      (listarTurmas as jest.Mock).mockResolvedValue([mockTurmas[0]]); 
+
+      render(<ListaTurmas />);
+      await waitFor(() => expect(screen.getByText('Anatomia Sistêmica')).toBeInTheDocument());
+
+      const btnExcluir = screen.getByRole('button', { name: /Excluir/i });
+      await user.click(btnExcluir);
+
+      expect(screen.getByTestId('mock-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('modal-turma-nome')).toHaveTextContent('Anatomia Sistêmica');
+
+      await user.click(screen.getByTestId('modal-btn-cancelar'));
+
+      expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+    });
+
+    it('deve chamar a API de exclusão, fechar o modal e recarregar a lista ao confirmar', async () => {
+      const user = userEvent.setup();
+      (listarTurmas as jest.Mock).mockResolvedValue([mockTurmas[0]]);
+      (excluirTurma as jest.Mock).mockResolvedValue(undefined);
+
+      render(<ListaTurmas />);
+      await waitFor(() => expect(screen.getByText('Anatomia Sistêmica')).toBeInTheDocument());
+
+      await user.click(screen.getByRole('button', { name: /Excluir/i }));
+      await user.click(screen.getByTestId('modal-btn-confirmar'));
+
+      // Validações
+      expect(excluirTurma).toHaveBeenCalledWith('turma-1');
+      expect(listarTurmas).toHaveBeenCalledTimes(2); 
+      expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+    });
+
+    it('deve lidar com erro na API de exclusão e fechar o estado de loading', async () => {
+      const user = userEvent.setup();
+      const erroExclusao = new Error('Falha ao excluir');
+      
+      (listarTurmas as jest.Mock).mockResolvedValue([mockTurmas[0]]);
+      (excluirTurma as jest.Mock).mockRejectedValue(erroExclusao);
+
+      render(<ListaTurmas />);
+      await waitFor(() => expect(screen.getByText('Anatomia Sistêmica')).toBeInTheDocument());
+
+      await user.click(screen.getByRole('button', { name: /Excluir/i }));
+      await user.click(screen.getByTestId('modal-btn-confirmar'));
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Erro ao excluir turma', erroExclusao);
+      });
+    });
+  });
+});

--- a/src/features/manage-turmas/ui/ListarTurmas.test.tsx
+++ b/src/features/manage-turmas/ui/ListarTurmas.test.tsx
@@ -1,32 +1,109 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ListaTurmas } from './ListarTurmas';
-import { listarTurmas, excluirTurma } from '../../../entities/turmas/api/turmaApi';
-import type { Turma } from '../../../entities/turmas/model/types';
+import {
+  atualizarTurma,
+  criarTurma,
+  excluirTurma,
+  listarTurmas,
+} from '../../../entities/turmas/api/turmaApi';
+import type { SalvarTurmaPayload, Turma } from '../../../entities/turmas/model/types';
 
 jest.mock('../../../entities/turmas/api/turmaApi', () => ({
-  listarTurmas: jest.fn(),
+  atualizarTurma: jest.fn(),
+  criarTurma: jest.fn(),
   excluirTurma: jest.fn(),
+  listarTurmas: jest.fn(),
+}));
+
+const payloadTurma: SalvarTurmaPayload = {
+  codigo: 'ANAT-01',
+  nome: 'Anatomia Sistemica',
+  semestre: '1',
+  ano: 2026,
+  descricao: 'Turma matutina',
+  status: 'ATIVA',
+};
+
+jest.mock('./ModalTurma', () => ({
+  ModalTurma: ({
+    isOpen,
+    mode,
+    turma,
+    onClose,
+    onSubmit,
+  }: {
+    isOpen: boolean;
+    mode: 'create' | 'edit';
+    turma: Turma | null;
+    onClose: () => void;
+    onSubmit: (payload: SalvarTurmaPayload) => void;
+  }) => {
+    if (!isOpen) return null;
+
+    return (
+      <div data-testid="mock-modal-turma">
+        <span>{mode}</span>
+        <span>{turma?.nome}</span>
+        <button onClick={onClose}>Fechar turma</button>
+        <button onClick={() => onSubmit(payloadTurma)}>Salvar turma mock</button>
+      </div>
+    );
+  },
+}));
+
+jest.mock('./ModalGerenciarAlunos', () => ({
+  ModalGerenciarAlunos: ({
+    isOpen,
+    turma,
+    onClose,
+    onAfterChange,
+    onFeedback,
+  }: {
+    isOpen: boolean;
+    turma: Turma | null;
+    onClose: () => void;
+    onAfterChange: () => void;
+    onFeedback: (message: string, type: 'success' | 'error') => void;
+  }) => {
+    if (!isOpen) return null;
+
+    return (
+      <div data-testid="mock-modal-alunos">
+        <span>{turma?.nome}</span>
+        <button onClick={onClose}>Fechar alunos</button>
+        <button
+          onClick={() => {
+            onFeedback('Aluno vinculado com sucesso.', 'success');
+            onAfterChange();
+          }}
+        >
+          Simular alteracao alunos
+        </button>
+      </div>
+    );
+  },
 }));
 
 jest.mock('./ModalExcluirTurma', () => ({
-  ModalExcluirTurma: ({ 
-    isOpen, 
-    onClose, 
-    onConfirm, 
-    turma 
-  }: { 
-    isOpen: boolean; 
-    onClose: () => void; 
-    onConfirm: () => void; 
-    turma: Turma | null; 
+  ModalExcluirTurma: ({
+    isOpen,
+    onClose,
+    onConfirm,
+    turma,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    turma: Turma | null;
   }) => {
     if (!isOpen) return null;
+
     return (
-      <div data-testid="mock-modal">
+      <div data-testid="mock-modal-excluir">
         <span data-testid="modal-turma-nome">{turma?.nome}</span>
-        <button onClick={onClose} data-testid="modal-btn-cancelar">Cancelar</button>
-        <button onClick={onConfirm} data-testid="modal-btn-confirmar">Confirmar Exclusão</button>
+        <button onClick={onClose}>Cancelar exclusao</button>
+        <button onClick={onConfirm}>Confirmar exclusao</button>
       </div>
     );
   },
@@ -36,7 +113,7 @@ const mockTurmas: Turma[] = [
   {
     id: 'turma-1',
     codigo: 'ANAT-01',
-    nome: 'Anatomia Sistêmica',
+    nome: 'Anatomia Sistemica',
     semestre: '1',
     ano: 2026,
     descricao: 'Turma matutina',
@@ -59,41 +136,39 @@ const mockTurmas: Turma[] = [
 
 describe('ListaTurmas Feature', () => {
   let consoleErrorSpy: jest.SpyInstance;
-  let windowAlertSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    windowAlertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+    (listarTurmas as jest.Mock).mockResolvedValue(mockTurmas);
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
-    windowAlertSpy.mockRestore();
   });
 
-    it('deve carregar e renderizar a lista de turmas na montagem inicial', async () => {
-    (listarTurmas as jest.Mock).mockResolvedValue(mockTurmas);
-
+  it('deve carregar e renderizar a lista de turmas na montagem inicial', async () => {
     render(<ListaTurmas />);
 
     await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(1));
-    expect(listarTurmas).toHaveBeenCalledWith({ busca: undefined, status: undefined });
+    expect(listarTurmas).toHaveBeenCalledWith({
+      busca: undefined,
+      status: undefined,
+      ano: undefined,
+      semestre: undefined,
+    });
 
-    expect(await screen.findByText('Anatomia Sistêmica')).toBeInTheDocument();
-    
+    expect(await screen.findByText('Anatomia Sistemica')).toBeInTheDocument();
     expect(screen.getByText('Neuroanatomia')).toBeInTheDocument();
     expect(screen.getByText('2 turmas cadastradas')).toBeInTheDocument();
   });
 
-  it('deve mostrar mensagem de lista vazia quando não houver turmas', async () => {
+  it('deve mostrar mensagem de lista vazia quando nao houver turmas', async () => {
     (listarTurmas as jest.Mock).mockResolvedValue([]);
 
     render(<ListaTurmas />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Nenhuma turma encontrada.')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Nenhuma turma encontrada.')).toBeInTheDocument();
   });
 
   it('deve lidar com erro na API ao carregar as turmas', async () => {
@@ -105,16 +180,15 @@ describe('ListaTurmas Feature', () => {
     await waitFor(() => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Erro ao carregar turmas', erroMock);
     });
+    expect(screen.getByRole('alert')).toHaveTextContent('Nao foi possivel carregar as turmas.');
   });
 
   it('deve disparar nova busca ao digitar no campo de pesquisa', async () => {
     const user = userEvent.setup();
-    (listarTurmas as jest.Mock).mockResolvedValue(mockTurmas);
 
     render(<ListaTurmas />);
 
     const inputBusca = screen.getByPlaceholderText('Buscar turma');
-    
     await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(1));
     jest.clearAllMocks();
 
@@ -122,97 +196,132 @@ describe('ListaTurmas Feature', () => {
 
     await waitFor(() => {
       expect(listarTurmas).toHaveBeenLastCalledWith(
-        expect.objectContaining({ busca: 'Anatomia' })
+        expect.objectContaining({ busca: 'Anatomia' }),
       );
     });
   });
 
-  it('deve disparar nova busca ao alterar o filtro de status', async () => {
+  it('deve disparar nova busca ao alterar filtros de ano, semestre e status', async () => {
     const user = userEvent.setup();
-    (listarTurmas as jest.Mock).mockResolvedValue(mockTurmas);
 
     render(<ListaTurmas />);
     await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(1));
     jest.clearAllMocks();
 
-    const selectStatus = screen.getByDisplayValue('Todos os status');
-    await user.selectOptions(selectStatus, 'ATIVA');
+    await user.selectOptions(screen.getByLabelText('Filtrar por ano'), '2026');
+    await user.selectOptions(screen.getByLabelText('Filtrar por semestre'), '1');
+    await user.selectOptions(screen.getByLabelText('Filtrar por status'), 'ATIVA');
 
     await waitFor(() => {
-      expect(listarTurmas).toHaveBeenCalledWith(
-        expect.objectContaining({ status: 'ATIVA' })
-      );
+      expect(listarTurmas).toHaveBeenLastCalledWith({
+        busca: undefined,
+        status: 'ATIVA',
+        ano: 2026,
+        semestre: '1',
+      });
     });
   });
 
-  it('deve disparar os alerts nos botões de feature futura (Nova Turma e Editar)', async () => {
+  it('deve abrir modal de criacao e criar turma', async () => {
     const user = userEvent.setup();
-    (listarTurmas as jest.Mock).mockResolvedValue([mockTurmas[0]]);
+    (criarTurma as jest.Mock).mockResolvedValue(mockTurmas[0]);
 
     render(<ListaTurmas />);
-    await waitFor(() => expect(screen.getByText('Anatomia Sistêmica')).toBeInTheDocument());
+    await screen.findByText('Anatomia Sistemica');
 
-    const btnNovaTurma = screen.getByRole('button', { name: /Nova Turma/i });
-    await user.click(btnNovaTurma);
-    expect(windowAlertSpy).toHaveBeenCalledWith('Abrir feature de Nova Turma');
+    await user.click(screen.getByRole('button', { name: /Nova Turma/i }));
+    expect(screen.getByTestId('mock-modal-turma')).toHaveTextContent('create');
 
-    const btnEditar = screen.getByRole('button', { name: /Editar/i });
-    await user.click(btnEditar);
-    expect(windowAlertSpy).toHaveBeenCalledWith('Abrir edição para Anatomia Sistêmica');
+    await user.click(screen.getByRole('button', { name: /Salvar turma mock/i }));
+
+    await waitFor(() => {
+      expect(criarTurma).toHaveBeenCalledWith(payloadTurma);
+    });
+    expect(await screen.findByRole('status')).toHaveTextContent('Turma criada com sucesso.');
   });
 
-  describe('Fluxo de Exclusão (Modal)', () => {
+  it('deve abrir modal de edicao e atualizar turma', async () => {
+    const user = userEvent.setup();
+    (atualizarTurma as jest.Mock).mockResolvedValue(mockTurmas[0]);
+
+    render(<ListaTurmas />);
+    await screen.findByText('Anatomia Sistemica');
+
+    await user.click(screen.getAllByRole('button', { name: /Editar/i })[0]);
+    expect(screen.getByTestId('mock-modal-turma')).toHaveTextContent('edit');
+    expect(screen.getByTestId('mock-modal-turma')).toHaveTextContent('Anatomia Sistemica');
+
+    await user.click(screen.getByRole('button', { name: /Salvar turma mock/i }));
+
+    await waitFor(() => {
+      expect(atualizarTurma).toHaveBeenCalledWith('turma-1', payloadTurma);
+    });
+    expect(await screen.findByRole('status')).toHaveTextContent('Turma atualizada com sucesso.');
+  });
+
+  it('deve abrir modal de alunos e atualizar listagem apos alteracao', async () => {
+    const user = userEvent.setup();
+
+    render(<ListaTurmas />);
+    await screen.findByText('Anatomia Sistemica');
+
+    await user.click(screen.getAllByRole('button', { name: /Alunos/i })[0]);
+    expect(screen.getByTestId('mock-modal-alunos')).toHaveTextContent('Anatomia Sistemica');
+
+    await user.click(screen.getByRole('button', { name: /Simular alteracao alunos/i }));
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Aluno vinculado com sucesso.');
+    await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(2));
+  });
+
+  describe('Fluxo de Exclusao', () => {
     it('deve abrir o modal ao clicar em excluir e permitir cancelar', async () => {
       const user = userEvent.setup();
-      (listarTurmas as jest.Mock).mockResolvedValue([mockTurmas[0]]); 
 
       render(<ListaTurmas />);
-      await waitFor(() => expect(screen.getByText('Anatomia Sistêmica')).toBeInTheDocument());
+      await screen.findByText('Anatomia Sistemica');
 
-      const btnExcluir = screen.getByRole('button', { name: /Excluir/i });
-      await user.click(btnExcluir);
+      await user.click(screen.getAllByRole('button', { name: /Excluir/i })[0]);
 
-      expect(screen.getByTestId('mock-modal')).toBeInTheDocument();
-      expect(screen.getByTestId('modal-turma-nome')).toHaveTextContent('Anatomia Sistêmica');
+      expect(screen.getByTestId('mock-modal-excluir')).toBeInTheDocument();
+      expect(screen.getByTestId('modal-turma-nome')).toHaveTextContent('Anatomia Sistemica');
 
-      await user.click(screen.getByTestId('modal-btn-cancelar'));
+      await user.click(screen.getByRole('button', { name: /Cancelar exclusao/i }));
 
-      expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('mock-modal-excluir')).not.toBeInTheDocument();
     });
 
-    it('deve chamar a API de exclusão, fechar o modal e recarregar a lista ao confirmar', async () => {
+    it('deve chamar a API de exclusao, fechar o modal e recarregar a lista ao confirmar', async () => {
       const user = userEvent.setup();
-      (listarTurmas as jest.Mock).mockResolvedValue([mockTurmas[0]]);
       (excluirTurma as jest.Mock).mockResolvedValue(undefined);
 
       render(<ListaTurmas />);
-      await waitFor(() => expect(screen.getByText('Anatomia Sistêmica')).toBeInTheDocument());
+      await screen.findByText('Anatomia Sistemica');
 
-      await user.click(screen.getByRole('button', { name: /Excluir/i }));
-      await user.click(screen.getByTestId('modal-btn-confirmar'));
+      await user.click(screen.getAllByRole('button', { name: /Excluir/i })[0]);
+      await user.click(screen.getByRole('button', { name: /Confirmar exclusao/i }));
 
-      // Validações
       expect(excluirTurma).toHaveBeenCalledWith('turma-1');
-      expect(listarTurmas).toHaveBeenCalledTimes(2); 
-      expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+      await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(2));
+      expect(screen.queryByTestId('mock-modal-excluir')).not.toBeInTheDocument();
+      expect(await screen.findByRole('status')).toHaveTextContent('Turma excluida com sucesso.');
     });
 
-    it('deve lidar com erro na API de exclusão e fechar o estado de loading', async () => {
+    it('deve lidar com erro na API de exclusao', async () => {
       const user = userEvent.setup();
       const erroExclusao = new Error('Falha ao excluir');
-      
-      (listarTurmas as jest.Mock).mockResolvedValue([mockTurmas[0]]);
       (excluirTurma as jest.Mock).mockRejectedValue(erroExclusao);
 
       render(<ListaTurmas />);
-      await waitFor(() => expect(screen.getByText('Anatomia Sistêmica')).toBeInTheDocument());
+      await screen.findByText('Anatomia Sistemica');
 
-      await user.click(screen.getByRole('button', { name: /Excluir/i }));
-      await user.click(screen.getByTestId('modal-btn-confirmar'));
+      await user.click(screen.getAllByRole('button', { name: /Excluir/i })[0]);
+      await user.click(screen.getByRole('button', { name: /Confirmar exclusao/i }));
 
       await waitFor(() => {
         expect(consoleErrorSpy).toHaveBeenCalledWith('Erro ao excluir turma', erroExclusao);
       });
+      expect(screen.getByRole('alert')).toHaveTextContent('Nao foi possivel excluir a turma.');
     });
   });
 });

--- a/src/features/manage-turmas/ui/ListarTurmas.tsx
+++ b/src/features/manage-turmas/ui/ListarTurmas.tsx
@@ -1,0 +1,182 @@
+import { useState, useEffect } from 'react';
+import { Search, Plus, Users, Edit, Trash2 } from 'lucide-react';
+import type { Turma } from '../../../entities/turmas/model/types';
+import { listarTurmas, excluirTurma } from '../../../entities/turmas/api/turmaApi';
+import { ModalExcluirTurma } from './ModalExcluirTurma';
+
+export const ListaTurmas = () => {
+  const [turmas, setTurmas] = useState<Turma[]>([]);
+  const [busca, setBusca] = useState('');
+  const [statusFiltro, setStatusFiltro] = useState<string>('');
+  
+  const [atualizarLista, setAtualizarLista] = useState(0); 
+  
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [turmaSelecionada, setTurmaSelecionada] = useState<Turma | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    const fetchTurmas = async () => {
+      try {
+        const dados = await listarTurmas({ 
+          busca: busca || undefined, 
+          status: statusFiltro ? (statusFiltro as Turma['status']) : undefined 
+        });
+        setTurmas(dados);
+      } catch (error) {
+        console.error('Erro ao carregar turmas', error);
+      }
+    };
+
+    fetchTurmas();
+  }, [busca, statusFiltro, atualizarLista]); 
+
+  const handleAbrirModalExcluir = (turma: Turma) => {
+    setTurmaSelecionada(turma);
+    setIsModalOpen(true);
+  };
+
+  const handleConfirmarExclusao = async () => {
+    if (!turmaSelecionada) return;
+    setIsDeleting(true);
+    try {
+      await excluirTurma(turmaSelecionada.id);
+      setIsModalOpen(false);
+      setTurmaSelecionada(null);
+      
+      setAtualizarLista(prev => prev + 1); 
+      
+    } catch (error) {
+      console.error('Erro ao excluir turma', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <div className="mb-6 flex items-center justify-between rounded-xl bg-white p-6 shadow-sm border border-gray-100">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900">Suas turmas</h2>
+          <p className="text-sm text-gray-500">{turmas.length} turmas cadastradas</p>
+        </div>
+        
+        <button 
+          onClick={() => alert('Abrir feature de Nova Turma')}
+          className="flex items-center gap-2 rounded-lg bg-teal-400 px-4 py-2.5 text-sm font-bold text-teal-950 hover:bg-teal-500 transition-colors"
+        >
+          <Plus size={18} />
+          Nova Turma
+        </button>
+      </div>
+
+      <div className="mb-6 flex items-center gap-4">
+        <div className="flex flex-1 items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm focus-within:border-teal-500 focus-within:ring-1 focus-within:ring-teal-500">
+          <Search size={18} className="text-gray-400" />
+          <input
+            type="text"
+            placeholder="Buscar turma"
+            className="w-full bg-transparent text-sm text-gray-900 outline-none placeholder:text-gray-400"
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+          />
+        </div>
+
+        <select className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-700 shadow-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500">
+          <option value="">Todos os semestres</option>
+          <option value="2026.1">2026.1</option>
+          <option value="2025.2">2025.2</option>
+        </select>
+
+        <select 
+          className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-700 shadow-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+          value={statusFiltro}
+          onChange={(e) => setStatusFiltro(e.target.value)}
+        >
+          <option value="">Todos os status</option>
+          <option value="ATIVA">Ativa</option>
+          <option value="INATIVA">Encerrada</option>
+        </select>
+
+        <span className="text-sm text-gray-500">{turmas.length} resultado(s)</span>
+      </div>
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <table className="w-full text-left text-sm text-gray-600">
+          <thead className="border-b border-gray-200 bg-gray-50 text-xs font-semibold tracking-wider text-gray-500 uppercase">
+            <tr>
+              <th className="px-6 py-4">Turma</th>
+              <th className="px-6 py-4">Semestre</th>
+              <th className="px-6 py-4">Descrição</th>
+              <th className="px-6 py-4">Alunos</th>
+              <th className="px-6 py-4">Status</th>
+              <th className="px-6 py-4">Criada em</th>
+              <th className="px-6 py-4">Ações</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {turmas.map((turma) => (
+              <tr key={turma.id} className="hover:bg-gray-50/50">
+                <td className="px-6 py-4 font-bold text-gray-900">{turma.nome}</td>
+                <td className="px-6 py-4">{turma.ano}.{turma.semestre}</td>
+                <td className="px-6 py-4">{turma.descricao}</td>
+                <td className="px-6 py-4 font-medium text-gray-900 flex items-center gap-1.5 mt-0.5">
+                  <Users size={16} className="text-gray-400" />
+                  {turma.quantidadeAlunos}
+                </td>
+                <td className="px-6 py-4">
+                  <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
+                    turma.status === 'ATIVA' 
+                      ? 'bg-teal-100 text-teal-800' 
+                      : 'bg-amber-100 text-amber-800'
+                  }`}>
+                    <span className={`h-1.5 w-1.5 rounded-full ${turma.status === 'ATIVA' ? 'bg-teal-600' : 'bg-amber-600'}`}></span>
+                    {turma.status === 'ATIVA' ? 'Ativa' : 'Encerrada'}
+                  </span>
+                </td>
+                <td className="px-6 py-4">{new Date(turma.criadoEm).toLocaleDateString('pt-BR')}</td>
+                <td className="px-6 py-4">
+                  <div className="flex gap-2">
+                    <button className="flex items-center gap-1.5 rounded-md border border-teal-200 bg-teal-50 px-3 py-1.5 text-xs font-semibold text-teal-700 hover:bg-teal-100 transition-colors">
+                      <Users size={14} />
+                      Alunos
+                    </button>
+                    <button 
+                      onClick={() => alert(`Abrir edição para ${turma.nome}`)}
+                      className="flex items-center gap-1.5 rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700 hover:bg-blue-100 transition-colors"
+                    >
+                      <Edit size={14} />
+                      Editar
+                    </button>
+                    <button 
+                      onClick={() => handleAbrirModalExcluir(turma)}
+                      className="flex items-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-100 transition-colors"
+                    >
+                      <Trash2 size={14} />
+                      Excluir
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            
+            {turmas.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-6 py-8 text-center text-gray-500">
+                  Nenhuma turma encontrada.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <ModalExcluirTurma 
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={handleConfirmarExclusao}
+        turma={turmaSelecionada}
+        isLoading={isDeleting}
+      />
+    </div>
+  );
+};

--- a/src/features/manage-turmas/ui/ListarTurmas.tsx
+++ b/src/features/manage-turmas/ui/ListarTurmas.tsx
@@ -1,53 +1,149 @@
-import { useState, useEffect } from 'react';
-import { Search, Plus, Users, Edit, Trash2 } from 'lucide-react';
-import type { Turma } from '../../../entities/turmas/model/types';
-import { listarTurmas, excluirTurma } from '../../../entities/turmas/api/turmaApi';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertCircle, CheckCircle2, Edit, Plus, Search, Trash2, Users } from 'lucide-react';
+import type { SalvarTurmaPayload, StatusTurma, Turma } from '../../../entities/turmas/model/types';
+import {
+  atualizarTurma,
+  criarTurma,
+  excluirTurma,
+  listarTurmas,
+} from '../../../entities/turmas/api/turmaApi';
 import { ModalExcluirTurma } from './ModalExcluirTurma';
+import { ModalGerenciarAlunos } from './ModalGerenciarAlunos';
+import { ModalTurma } from './ModalTurma';
+
+type ToastType = 'success' | 'error';
+
+interface ToastState {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+const anosDisponiveis = () => {
+  const anoAtual = new Date().getFullYear();
+  return [anoAtual + 1, anoAtual, anoAtual - 1, anoAtual - 2];
+};
 
 export const ListaTurmas = () => {
   const [turmas, setTurmas] = useState<Turma[]>([]);
   const [busca, setBusca] = useState('');
-  const [statusFiltro, setStatusFiltro] = useState<string>('');
-  
-  const [atualizarLista, setAtualizarLista] = useState(0); 
-  
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [statusFiltro, setStatusFiltro] = useState('');
+  const [anoFiltro, setAnoFiltro] = useState('');
+  const [semestreFiltro, setSemestreFiltro] = useState('');
+  const [atualizarLista, setAtualizarLista] = useState(0);
+
+  const [isModalExcluirOpen, setIsModalExcluirOpen] = useState(false);
+  const [isModalTurmaOpen, setIsModalTurmaOpen] = useState(false);
+  const [isModalAlunosOpen, setIsModalAlunosOpen] = useState(false);
+  const [modoModalTurma, setModoModalTurma] = useState<'create' | 'edit'>('create');
   const [turmaSelecionada, setTurmaSelecionada] = useState<Turma | null>(null);
+  const [turmaAlunos, setTurmaAlunos] = useState<Turma | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isSavingTurma, setIsSavingTurma] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const anos = useMemo(() => anosDisponiveis(), []);
+
+  const mostrarToast = useCallback((message: string, type: ToastType = 'success') => {
+    setToast({ id: Date.now(), message, type });
+  }, []);
+
+  useEffect(() => {
+    if (!toast) return undefined;
+
+    const timeoutId = window.setTimeout(() => {
+      setToast(null);
+    }, 3500);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [toast]);
 
   useEffect(() => {
     const fetchTurmas = async () => {
       try {
-        const dados = await listarTurmas({ 
-          busca: busca || undefined, 
-          status: statusFiltro ? (statusFiltro as Turma['status']) : undefined 
+        const dados = await listarTurmas({
+          busca: busca || undefined,
+          status: statusFiltro ? (statusFiltro as StatusTurma) : undefined,
+          ano: anoFiltro ? Number(anoFiltro) : undefined,
+          semestre: semestreFiltro || undefined,
         });
         setTurmas(dados);
       } catch (error) {
         console.error('Erro ao carregar turmas', error);
+        mostrarToast('Nao foi possivel carregar as turmas.', 'error');
       }
     };
 
-    fetchTurmas();
-  }, [busca, statusFiltro, atualizarLista]); 
+    void fetchTurmas();
+  }, [anoFiltro, atualizarLista, busca, mostrarToast, semestreFiltro, statusFiltro]);
+
+  const atualizarTurmas = () => {
+    setAtualizarLista((prev) => prev + 1);
+  };
 
   const handleAbrirModalExcluir = (turma: Turma) => {
     setTurmaSelecionada(turma);
-    setIsModalOpen(true);
+    setIsModalExcluirOpen(true);
+  };
+
+  const handleAbrirModalCriar = () => {
+    setModoModalTurma('create');
+    setTurmaSelecionada(null);
+    setIsModalTurmaOpen(true);
+  };
+
+  const handleAbrirModalEditar = (turma: Turma) => {
+    setModoModalTurma('edit');
+    setTurmaSelecionada(turma);
+    setIsModalTurmaOpen(true);
+  };
+
+  const handleAbrirModalAlunos = (turma: Turma) => {
+    setTurmaAlunos(turma);
+    setIsModalAlunosOpen(true);
+  };
+
+  const handleFecharModalTurma = () => {
+    setIsModalTurmaOpen(false);
+    setTurmaSelecionada(null);
+  };
+
+  const handleSalvarTurma = async (payload: SalvarTurmaPayload) => {
+    setIsSavingTurma(true);
+
+    try {
+      if (modoModalTurma === 'create') {
+        await criarTurma(payload);
+        mostrarToast('Turma criada com sucesso.');
+      } else if (turmaSelecionada) {
+        await atualizarTurma(turmaSelecionada.id, payload);
+        mostrarToast('Turma atualizada com sucesso.');
+      }
+
+      handleFecharModalTurma();
+      atualizarTurmas();
+    } catch (error) {
+      console.error('Erro ao salvar turma', error);
+      mostrarToast('Nao foi possivel salvar a turma.', 'error');
+    } finally {
+      setIsSavingTurma(false);
+    }
   };
 
   const handleConfirmarExclusao = async () => {
     if (!turmaSelecionada) return;
+
     setIsDeleting(true);
+
     try {
       await excluirTurma(turmaSelecionada.id);
-      setIsModalOpen(false);
+      setIsModalExcluirOpen(false);
       setTurmaSelecionada(null);
-      
-      setAtualizarLista(prev => prev + 1); 
-      
+      mostrarToast('Turma excluida com sucesso.');
+      atualizarTurmas();
     } catch (error) {
       console.error('Erro ao excluir turma', error);
+      mostrarToast('Nao foi possivel excluir a turma.', 'error');
     } finally {
       setIsDeleting(false);
     }
@@ -55,23 +151,38 @@ export const ListaTurmas = () => {
 
   return (
     <div className="w-full">
-      <div className="mb-6 flex items-center justify-between rounded-xl bg-white p-6 shadow-sm border border-gray-100">
+      {toast && (
+        <div
+          key={toast.id}
+          role={toast.type === 'error' ? 'alert' : 'status'}
+          className={`fixed right-6 top-6 z-[60] flex max-w-sm items-center gap-3 rounded-lg border px-4 py-3 text-sm font-medium shadow-lg ${
+            toast.type === 'success'
+              ? 'border-teal-200 bg-teal-50 text-teal-800'
+              : 'border-red-200 bg-red-50 text-red-800'
+          }`}
+        >
+          {toast.type === 'success' ? <CheckCircle2 size={18} /> : <AlertCircle size={18} />}
+          <span>{toast.message}</span>
+        </div>
+      )}
+
+      <div className="mb-6 flex items-center justify-between rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
         <div>
           <h2 className="text-xl font-bold text-gray-900">Suas turmas</h2>
           <p className="text-sm text-gray-500">{turmas.length} turmas cadastradas</p>
         </div>
-        
-        <button 
-          onClick={() => alert('Abrir feature de Nova Turma')}
-          className="flex items-center gap-2 rounded-lg bg-teal-400 px-4 py-2.5 text-sm font-bold text-teal-950 hover:bg-teal-500 transition-colors"
+
+        <button
+          onClick={handleAbrirModalCriar}
+          className="flex items-center gap-2 rounded-lg bg-teal-400 px-4 py-2.5 text-sm font-bold text-teal-950 transition-colors hover:bg-teal-500"
         >
           <Plus size={18} />
           Nova Turma
         </button>
       </div>
 
-      <div className="mb-6 flex items-center gap-4">
-        <div className="flex flex-1 items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm focus-within:border-teal-500 focus-within:ring-1 focus-within:ring-teal-500">
+      <div className="mb-6 flex flex-wrap items-center gap-4">
+        <div className="flex min-w-64 flex-1 items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm focus-within:border-teal-500 focus-within:ring-1 focus-within:ring-teal-500">
           <Search size={18} className="text-gray-400" />
           <input
             type="text"
@@ -82,13 +193,33 @@ export const ListaTurmas = () => {
           />
         </div>
 
-        <select className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-700 shadow-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500">
-          <option value="">Todos os semestres</option>
-          <option value="2026.1">2026.1</option>
-          <option value="2025.2">2025.2</option>
+        <select
+          aria-label="Filtrar por ano"
+          className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-700 shadow-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+          value={anoFiltro}
+          onChange={(e) => setAnoFiltro(e.target.value)}
+        >
+          <option value="">Todos os anos</option>
+          {anos.map((ano) => (
+            <option key={ano} value={ano}>
+              {ano}
+            </option>
+          ))}
         </select>
 
-        <select 
+        <select
+          aria-label="Filtrar por semestre"
+          className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-700 shadow-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+          value={semestreFiltro}
+          onChange={(e) => setSemestreFiltro(e.target.value)}
+        >
+          <option value="">Todos os semestres</option>
+          <option value="1">1</option>
+          <option value="2">2</option>
+        </select>
+
+        <select
+          aria-label="Filtrar por status"
           className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-700 shadow-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
           value={statusFiltro}
           onChange={(e) => setStatusFiltro(e.target.value)}
@@ -100,17 +231,18 @@ export const ListaTurmas = () => {
 
         <span className="text-sm text-gray-500">{turmas.length} resultado(s)</span>
       </div>
+
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
         <table className="w-full text-left text-sm text-gray-600">
-          <thead className="border-b border-gray-200 bg-gray-50 text-xs font-semibold tracking-wider text-gray-500 uppercase">
+          <thead className="border-b border-gray-200 bg-gray-50 text-xs font-semibold uppercase tracking-wider text-gray-500">
             <tr>
               <th className="px-6 py-4">Turma</th>
               <th className="px-6 py-4">Semestre</th>
-              <th className="px-6 py-4">Descrição</th>
+              <th className="px-6 py-4">Descricao</th>
               <th className="px-6 py-4">Alunos</th>
               <th className="px-6 py-4">Status</th>
               <th className="px-6 py-4">Criada em</th>
-              <th className="px-6 py-4">Ações</th>
+              <th className="px-6 py-4">Acoes</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200">
@@ -119,37 +251,43 @@ export const ListaTurmas = () => {
                 <td className="px-6 py-4 font-bold text-gray-900">{turma.nome}</td>
                 <td className="px-6 py-4">{turma.ano}.{turma.semestre}</td>
                 <td className="px-6 py-4">{turma.descricao}</td>
-                <td className="px-6 py-4 font-medium text-gray-900 flex items-center gap-1.5 mt-0.5">
-                  <Users size={16} className="text-gray-400" />
-                  {turma.quantidadeAlunos}
+                <td className="px-6 py-4">
+                  <span className="flex items-center gap-1.5 font-medium text-gray-900">
+                    <Users size={16} className="text-gray-400" />
+                    {turma.quantidadeAlunos}
+                  </span>
                 </td>
                 <td className="px-6 py-4">
                   <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
-                    turma.status === 'ATIVA' 
-                      ? 'bg-teal-100 text-teal-800' 
+                    turma.status === 'ATIVA'
+                      ? 'bg-teal-100 text-teal-800'
                       : 'bg-amber-100 text-amber-800'
-                  }`}>
-                    <span className={`h-1.5 w-1.5 rounded-full ${turma.status === 'ATIVA' ? 'bg-teal-600' : 'bg-amber-600'}`}></span>
+                  }`}
+                  >
+                    <span className={`h-1.5 w-1.5 rounded-full ${turma.status === 'ATIVA' ? 'bg-teal-600' : 'bg-amber-600'}`} />
                     {turma.status === 'ATIVA' ? 'Ativa' : 'Encerrada'}
                   </span>
                 </td>
                 <td className="px-6 py-4">{new Date(turma.criadoEm).toLocaleDateString('pt-BR')}</td>
                 <td className="px-6 py-4">
                   <div className="flex gap-2">
-                    <button className="flex items-center gap-1.5 rounded-md border border-teal-200 bg-teal-50 px-3 py-1.5 text-xs font-semibold text-teal-700 hover:bg-teal-100 transition-colors">
+                    <button
+                      onClick={() => handleAbrirModalAlunos(turma)}
+                      className="flex items-center gap-1.5 rounded-md border border-teal-200 bg-teal-50 px-3 py-1.5 text-xs font-semibold text-teal-700 transition-colors hover:bg-teal-100"
+                    >
                       <Users size={14} />
                       Alunos
                     </button>
-                    <button 
-                      onClick={() => alert(`Abrir edição para ${turma.nome}`)}
-                      className="flex items-center gap-1.5 rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700 hover:bg-blue-100 transition-colors"
+                    <button
+                      onClick={() => handleAbrirModalEditar(turma)}
+                      className="flex items-center gap-1.5 rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-100"
                     >
                       <Edit size={14} />
                       Editar
                     </button>
-                    <button 
+                    <button
                       onClick={() => handleAbrirModalExcluir(turma)}
-                      className="flex items-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-100 transition-colors"
+                      className="flex items-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 transition-colors hover:bg-red-100"
                     >
                       <Trash2 size={14} />
                       Excluir
@@ -158,7 +296,7 @@ export const ListaTurmas = () => {
                 </td>
               </tr>
             ))}
-            
+
             {turmas.length === 0 && (
               <tr>
                 <td colSpan={7} className="px-6 py-8 text-center text-gray-500">
@@ -170,9 +308,28 @@ export const ListaTurmas = () => {
         </table>
       </div>
 
-      <ModalExcluirTurma 
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
+      <ModalTurma
+        key={`${modoModalTurma}-${turmaSelecionada?.id ?? 'nova'}-${isModalTurmaOpen ? 'open' : 'closed'}`}
+        isOpen={isModalTurmaOpen}
+        mode={modoModalTurma}
+        turma={turmaSelecionada}
+        isLoading={isSavingTurma}
+        onClose={handleFecharModalTurma}
+        onSubmit={handleSalvarTurma}
+      />
+
+      <ModalGerenciarAlunos
+        key={`${turmaAlunos?.id ?? 'sem-turma'}-${isModalAlunosOpen ? 'open' : 'closed'}`}
+        isOpen={isModalAlunosOpen}
+        turma={turmaAlunos}
+        onClose={() => setIsModalAlunosOpen(false)}
+        onAfterChange={atualizarTurmas}
+        onFeedback={mostrarToast}
+      />
+
+      <ModalExcluirTurma
+        isOpen={isModalExcluirOpen}
+        onClose={() => setIsModalExcluirOpen(false)}
         onConfirm={handleConfirmarExclusao}
         turma={turmaSelecionada}
         isLoading={isDeleting}

--- a/src/features/manage-turmas/ui/ModalExcluirTurma.test.tsx
+++ b/src/features/manage-turmas/ui/ModalExcluirTurma.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModalExcluirTurma } from './ModalExcluirTurma'; 
+import type { Turma } from '../../../entities/turmas/model/types';
+
+describe('ModalExcluirTurma', () => {
+  const mockTurma: Turma = {
+    id: 'turma-123',
+    codigo: 'ANAT-01',
+    nome: 'Anatomia Sistêmica',
+    semestre: '1',
+    ano: 2026,
+    descricao: 'Turma de Teste',
+    status: 'ATIVA',
+    quantidadeAlunos: 42,
+    criadoEm: '2026-05-16T10:00:00.000Z',
+  };
+
+  const mockOnClose = jest.fn();
+  const mockOnConfirm = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('não deve renderizar o modal se isOpen for false', () => {
+    const { container } = render(
+      <ModalExcluirTurma
+        isOpen={false}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        turma={mockTurma}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('não deve renderizar o modal se a turma for null', () => {
+    const { container } = render(
+      <ModalExcluirTurma
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        turma={null}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('deve renderizar corretamente os dados da turma quando aberto', () => {
+    render(
+      <ModalExcluirTurma
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        turma={mockTurma}
+      />
+    );
+
+    expect(screen.getByText('Excluir turma?')).toBeInTheDocument();
+    
+    expect(screen.getByText('Anatomia Sistêmica · 2026.1 · 42 alunos')).toBeInTheDocument();
+  });
+
+  it('deve chamar onClose ao clicar no botão Cancelar', async () => {
+    const user = userEvent.setup();
+    render(
+      <ModalExcluirTurma
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        turma={mockTurma}
+      />
+    );
+
+    const btnCancelar = screen.getByRole('button', { name: /Cancelar/i });
+    await user.click(btnCancelar);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+
+  it('deve chamar onConfirm ao clicar no botão Excluir', async () => {
+    const user = userEvent.setup();
+    render(
+      <ModalExcluirTurma
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        turma={mockTurma}
+      />
+    );
+
+    const btnExcluir = screen.getByRole('button', { name: 'Excluir' });
+    await user.click(btnExcluir);
+
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('deve desabilitar os botões e mudar o texto quando isLoading for true', () => {
+    render(
+      <ModalExcluirTurma
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        turma={mockTurma}
+        isLoading={true}
+      />
+    );
+
+    const btnCancelar = screen.getByRole('button', { name: /Cancelar/i });
+    const btnExcluir = screen.getByRole('button', { name: /Excluindo\.\.\./i });
+
+    expect(btnCancelar).toBeDisabled();
+    expect(btnExcluir).toBeDisabled();
+  });
+});

--- a/src/features/manage-turmas/ui/ModalExcluirTurma.tsx
+++ b/src/features/manage-turmas/ui/ModalExcluirTurma.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Trash2 } from 'lucide-react';
+import type { Turma } from '../../../entities/turmas/model/types';
+
+interface ModalExcluirTurmaProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  turma: Turma | null;
+  isLoading?: boolean;
+}
+
+export const ModalExcluirTurma: React.FC<ModalExcluirTurmaProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  turma,
+  isLoading
+}) => {
+  if (!isOpen || !turma) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+        <h3 className="mb-2 text-lg font-bold text-gray-900">Excluir turma?</h3>
+        
+        <p className="mb-6 text-sm text-gray-500">
+          Esta ação removerá a turma e desvinculará todos os alunos. Confirme para excluir:
+        </p>
+
+        <div className="mb-6 rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
+          {turma.nome} · {turma.ano}.{turma.semestre} · {turma.quantidadeAlunos} alunos
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={isLoading}
+            className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+          >
+            <Trash2 size={16} />
+            {isLoading ? 'Excluindo...' : 'Excluir'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/manage-turmas/ui/ModalGerenciarAlunos.test.tsx
+++ b/src/features/manage-turmas/ui/ModalGerenciarAlunos.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModalGerenciarAlunos } from './ModalGerenciarAlunos';
+import {
+  desvincularAlunoTurma,
+  listarAlunosDaTurma,
+  vincularAlunoTurma,
+} from '../../../entities/turmas/api/turmaApi';
+import { buscarAlunos, buscarUsuariosPorIds } from '../../../entities/usuarios/api/usuarioApi';
+import type { Turma } from '../../../entities/turmas/model/types';
+
+jest.mock('../../../entities/turmas/api/turmaApi', () => ({
+  desvincularAlunoTurma: jest.fn(),
+  listarAlunosDaTurma: jest.fn(),
+  vincularAlunoTurma: jest.fn(),
+}));
+
+jest.mock('../../../entities/usuarios/api/usuarioApi', () => ({
+  buscarAlunos: jest.fn(),
+  buscarUsuariosPorIds: jest.fn(),
+}));
+
+const turma: Turma = {
+  id: 'turma-1',
+  codigo: 'ANAT-01',
+  nome: 'Anatomia Sistemica',
+  semestre: '1',
+  ano: 2026,
+  descricao: 'Turma matutina',
+  status: 'ATIVA',
+  quantidadeAlunos: 15,
+  criadoEm: '2026-05-14T10:00:00.000Z',
+};
+
+const alunoVinculado = {
+  id: 'aluno-1',
+  nome: 'Joao Silva',
+  nickname: 'joao',
+  email: 'joao@example.com',
+  perfil: 'ALUNO',
+  status: 'ATIVO',
+  instituicao: 'UnB',
+  curso: 'Medicina',
+  semestre: '2026.1',
+};
+
+const alunoBusca = {
+  id: 'aluno-2',
+  nome: 'Maria Santos',
+  nickname: 'maria',
+  email: 'maria@example.com',
+  perfil: 'ALUNO',
+  status: 'ATIVO',
+  instituicao: 'UnB',
+  curso: 'Medicina',
+  semestre: '2026.1',
+};
+
+describe('ModalGerenciarAlunos', () => {
+  const onClose = jest.fn();
+  const onAfterChange = jest.fn();
+  const onFeedback = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (listarAlunosDaTurma as jest.Mock).mockResolvedValue([
+      {
+        id: 'vinculo-1',
+        turmaId: 'turma-1',
+        alunoId: 'aluno-1',
+        criadoEm: '2026-05-14T10:00:00.000Z',
+        atualizadoEm: '2026-05-14T10:00:00.000Z',
+      },
+    ]);
+    (buscarUsuariosPorIds as jest.Mock).mockResolvedValue([alunoVinculado]);
+    (buscarAlunos as jest.Mock).mockResolvedValue({
+      dados: [alunoBusca],
+      metadados: { page: 1, limit: 10, total: 1, totalPages: 1 },
+    });
+    (vincularAlunoTurma as jest.Mock).mockResolvedValue({});
+    (desvincularAlunoTurma as jest.Mock).mockResolvedValue({});
+  });
+
+  it('nao deve renderizar quando estiver fechado', () => {
+    const { container } = render(
+      <ModalGerenciarAlunos
+        isOpen={false}
+        turma={turma}
+        onClose={onClose}
+        onAfterChange={onAfterChange}
+        onFeedback={onFeedback}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('deve carregar vinculos e buscar dados dos alunos', async () => {
+    render(
+      <ModalGerenciarAlunos
+        isOpen={true}
+        turma={turma}
+        onClose={onClose}
+        onAfterChange={onAfterChange}
+        onFeedback={onFeedback}
+      />,
+    );
+
+    expect(await screen.findByText('Joao Silva')).toBeInTheDocument();
+    expect(listarAlunosDaTurma).toHaveBeenCalledWith('turma-1');
+    expect(buscarUsuariosPorIds).toHaveBeenCalledWith(['aluno-1']);
+  });
+
+  it('deve buscar alunos por texto e vincular aluno selecionado', async () => {
+    const user = userEvent.setup();
+    render(
+      <ModalGerenciarAlunos
+        isOpen={true}
+        turma={turma}
+        onClose={onClose}
+        onAfterChange={onAfterChange}
+        onFeedback={onFeedback}
+      />,
+    );
+
+    await screen.findByText('Joao Silva');
+    await user.type(screen.getByPlaceholderText('Buscar por nome ou email'), 'Maria');
+
+    expect(await screen.findByText('Maria Santos')).toBeInTheDocument();
+    expect(buscarAlunos).toHaveBeenCalledWith({ busca: 'Maria', limit: 10 });
+
+    await user.click(screen.getByRole('button', { name: /Adicionar/i }));
+
+    await waitFor(() => {
+      expect(vincularAlunoTurma).toHaveBeenCalledWith('turma-1', 'aluno-2');
+    });
+    expect(onFeedback).toHaveBeenCalledWith('Aluno vinculado com sucesso.', 'success');
+    expect(onAfterChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('deve impedir adicionar aluno ja vinculado', async () => {
+    const user = userEvent.setup();
+    (buscarAlunos as jest.Mock).mockResolvedValue({
+      dados: [alunoVinculado],
+      metadados: { page: 1, limit: 10, total: 1, totalPages: 1 },
+    });
+
+    render(
+      <ModalGerenciarAlunos
+        isOpen={true}
+        turma={turma}
+        onClose={onClose}
+        onAfterChange={onAfterChange}
+        onFeedback={onFeedback}
+      />,
+    );
+
+    await screen.findByText('Joao Silva');
+    await user.type(screen.getByPlaceholderText('Buscar por nome ou email'), 'Joao');
+
+    const botaoVinculado = await screen.findByRole('button', { name: /Vinculado/i });
+    expect(botaoVinculado).toBeDisabled();
+  });
+
+  it('deve desvincular aluno', async () => {
+    const user = userEvent.setup();
+    render(
+      <ModalGerenciarAlunos
+        isOpen={true}
+        turma={turma}
+        onClose={onClose}
+        onAfterChange={onAfterChange}
+        onFeedback={onFeedback}
+      />,
+    );
+
+    await screen.findByText('Joao Silva');
+    await user.click(screen.getByRole('button', { name: /Remover/i }));
+
+    await waitFor(() => {
+      expect(desvincularAlunoTurma).toHaveBeenCalledWith('turma-1', 'aluno-1');
+    });
+    expect(onFeedback).toHaveBeenCalledWith('Aluno removido da turma com sucesso.', 'success');
+    expect(onAfterChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/manage-turmas/ui/ModalGerenciarAlunos.tsx
+++ b/src/features/manage-turmas/ui/ModalGerenciarAlunos.tsx
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Loader2, Search, UserMinus, UserPlus, X } from 'lucide-react';
+import {
+  desvincularAlunoTurma,
+  listarAlunosDaTurma,
+  vincularAlunoTurma,
+} from '../../../entities/turmas/api/turmaApi';
+import type { Turma, VinculoTurmaAluno } from '../../../entities/turmas/model/types';
+import { buscarAlunos, buscarUsuariosPorIds } from '../../../entities/usuarios/api/usuarioApi';
+import type { UsuarioResumo } from '../../../entities/usuarios/model/types';
+
+type TipoFeedback = 'success' | 'error';
+
+interface ModalGerenciarAlunosProps {
+  isOpen: boolean;
+  turma: Turma | null;
+  onClose: () => void;
+  onAfterChange: () => void;
+  onFeedback: (message: string, type: TipoFeedback) => void;
+}
+
+const criarAlunoFallback = (alunoId: string): UsuarioResumo => ({
+  id: alunoId,
+  nome: 'Aluno sem dados carregados',
+  nickname: null,
+  email: alunoId,
+  perfil: 'ALUNO',
+  status: 'ATIVO',
+  instituicao: null,
+  curso: null,
+  semestre: null,
+});
+
+export const ModalGerenciarAlunos = ({
+  isOpen,
+  turma,
+  onClose,
+  onAfterChange,
+  onFeedback,
+}: ModalGerenciarAlunosProps) => {
+  const [vinculos, setVinculos] = useState<VinculoTurmaAluno[]>([]);
+  const [alunosVinculados, setAlunosVinculados] = useState<UsuarioResumo[]>([]);
+  const [busca, setBusca] = useState('');
+  const [resultadosBusca, setResultadosBusca] = useState<UsuarioResumo[]>([]);
+  const [isLoadingVinculos, setIsLoadingVinculos] = useState(isOpen);
+  const [isBuscandoAlunos, setIsBuscandoAlunos] = useState(false);
+  const [alunoEmOperacao, setAlunoEmOperacao] = useState<string | null>(null);
+
+  const idsVinculados = useMemo(
+    () => new Set(vinculos.map((vinculo) => vinculo.alunoId)),
+    [vinculos],
+  );
+
+  const carregarAlunosVinculados = useCallback(async () => {
+    if (!turma) return;
+
+    setIsLoadingVinculos(true);
+
+    try {
+      const vinculosAtivos = await listarAlunosDaTurma(turma.id);
+      const alunoIds = vinculosAtivos.map((vinculo) => vinculo.alunoId);
+      const usuarios = await buscarUsuariosPorIds(alunoIds);
+      const usuariosPorId = new Map(usuarios.map((usuario) => [usuario.id, usuario]));
+
+      setVinculos(vinculosAtivos);
+      setAlunosVinculados(
+        alunoIds.map((alunoId) => usuariosPorId.get(alunoId) ?? criarAlunoFallback(alunoId)),
+      );
+    } catch (error) {
+      console.error('Erro ao carregar alunos da turma', error);
+      onFeedback('Nao foi possivel carregar os alunos da turma.', 'error');
+    } finally {
+      setIsLoadingVinculos(false);
+    }
+  }, [onFeedback, turma]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    const timeoutId = window.setTimeout(() => {
+      void carregarAlunosVinculados();
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [carregarAlunosVinculados, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    const termoBusca = busca.trim();
+    if (termoBusca.length < 2) {
+      return undefined;
+    }
+
+    let isCancelled = false;
+    const timeoutId = window.setTimeout(async () => {
+      setIsBuscandoAlunos(true);
+
+      try {
+        const resultado = await buscarAlunos({ busca: termoBusca, limit: 10 });
+
+        if (!isCancelled) {
+          setResultadosBusca(resultado.dados);
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          console.error('Erro ao buscar alunos', error);
+          onFeedback('Nao foi possivel buscar alunos.', 'error');
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsBuscandoAlunos(false);
+        }
+      }
+    }, 300);
+
+    return () => {
+      isCancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [busca, isOpen, onFeedback]);
+
+  if (!isOpen || !turma) return null;
+
+  const handleVincularAluno = async (alunoId: string) => {
+    setAlunoEmOperacao(alunoId);
+
+    try {
+      await vincularAlunoTurma(turma.id, alunoId);
+      onFeedback('Aluno vinculado com sucesso.', 'success');
+      await carregarAlunosVinculados();
+      onAfterChange();
+    } catch (error) {
+      console.error('Erro ao vincular aluno', error);
+      onFeedback('Nao foi possivel vincular o aluno.', 'error');
+    } finally {
+      setAlunoEmOperacao(null);
+    }
+  };
+
+  const handleDesvincularAluno = async (alunoId: string) => {
+    setAlunoEmOperacao(alunoId);
+
+    try {
+      await desvincularAlunoTurma(turma.id, alunoId);
+      onFeedback('Aluno removido da turma com sucesso.', 'success');
+      await carregarAlunosVinculados();
+      onAfterChange();
+    } catch (error) {
+      console.error('Erro ao desvincular aluno', error);
+      onFeedback('Nao foi possivel remover o aluno.', 'error');
+    } finally {
+      setAlunoEmOperacao(null);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm">
+      <div
+        aria-modal="true"
+        role="dialog"
+        aria-labelledby="modal-alunos-title"
+        className="flex max-h-[90vh] w-full max-w-4xl flex-col rounded-xl bg-white p-6 shadow-xl"
+      >
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div>
+            <h3 id="modal-alunos-title" className="text-lg font-bold text-gray-900">
+              Alunos da turma
+            </h3>
+            <p className="text-sm text-gray-500">
+              {turma.nome} · {turma.ano}.{turma.semestre}
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Fechar modal de alunos"
+            className="rounded-lg p-2 text-gray-500 hover:bg-gray-100"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="grid min-h-0 gap-6 lg:grid-cols-[1fr_1fr]">
+          <section className="min-h-0">
+            <div className="mb-3 flex items-center justify-between">
+              <h4 className="text-sm font-bold text-gray-900">Vinculados</h4>
+              <span className="text-xs font-medium text-gray-500">
+                {alunosVinculados.length} aluno(s)
+              </span>
+            </div>
+
+            <div className="max-h-96 overflow-y-auto rounded-lg border border-gray-200">
+              {isLoadingVinculos ? (
+                <div className="flex items-center justify-center gap-2 px-4 py-8 text-sm text-gray-500">
+                  <Loader2 size={16} className="animate-spin" />
+                  Carregando alunos...
+                </div>
+              ) : alunosVinculados.length === 0 ? (
+                <p className="px-4 py-8 text-center text-sm text-gray-500">
+                  Nenhum aluno vinculado.
+                </p>
+              ) : (
+                <ul className="divide-y divide-gray-200">
+                  {alunosVinculados.map((aluno) => (
+                    <li key={aluno.id} className="flex items-center justify-between gap-3 p-4">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-gray-900">{aluno.nome}</p>
+                        <p className="truncate text-xs text-gray-500">{aluno.email}</p>
+                      </div>
+
+                      <button
+                        type="button"
+                        onClick={() => void handleDesvincularAluno(aluno.id)}
+                        disabled={alunoEmOperacao === aluno.id}
+                        className="flex shrink-0 items-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-100 disabled:opacity-50"
+                      >
+                        {alunoEmOperacao === aluno.id ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <UserMinus size={14} />
+                        )}
+                        Remover
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </section>
+
+          <section className="min-h-0">
+            <h4 className="mb-3 text-sm font-bold text-gray-900">Buscar alunos</h4>
+
+            <div className="mb-3 flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus-within:border-teal-500 focus-within:ring-1 focus-within:ring-teal-500">
+              <Search size={18} className="text-gray-400" />
+              <input
+                value={busca}
+                onChange={(event) => setBusca(event.target.value)}
+                placeholder="Buscar por nome ou email"
+                className="w-full bg-transparent text-sm text-gray-900 outline-none placeholder:text-gray-400"
+              />
+            </div>
+
+            <div className="max-h-96 overflow-y-auto rounded-lg border border-gray-200">
+              {busca.trim().length < 2 ? (
+                <p className="px-4 py-8 text-center text-sm text-gray-500">
+                  Digite ao menos 2 caracteres para buscar.
+                </p>
+              ) : isBuscandoAlunos ? (
+                <div className="flex items-center justify-center gap-2 px-4 py-8 text-sm text-gray-500">
+                  <Loader2 size={16} className="animate-spin" />
+                  Buscando alunos...
+                </div>
+              ) : resultadosBusca.length === 0 ? (
+                <p className="px-4 py-8 text-center text-sm text-gray-500">
+                  Nenhum aluno encontrado.
+                </p>
+              ) : (
+                <ul className="divide-y divide-gray-200">
+                  {resultadosBusca.map((aluno) => {
+                    const jaVinculado = idsVinculados.has(aluno.id);
+
+                    return (
+                      <li key={aluno.id} className="flex items-center justify-between gap-3 p-4">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-semibold text-gray-900">{aluno.nome}</p>
+                          <p className="truncate text-xs text-gray-500">{aluno.email}</p>
+                        </div>
+
+                        <button
+                          type="button"
+                          onClick={() => void handleVincularAluno(aluno.id)}
+                          disabled={jaVinculado || alunoEmOperacao === aluno.id}
+                          className="flex shrink-0 items-center gap-1.5 rounded-md border border-teal-200 bg-teal-50 px-3 py-1.5 text-xs font-semibold text-teal-700 hover:bg-teal-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {alunoEmOperacao === aluno.id ? (
+                            <Loader2 size={14} className="animate-spin" />
+                          ) : (
+                            <UserPlus size={14} />
+                          )}
+                          {jaVinculado ? 'Vinculado' : 'Adicionar'}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/manage-turmas/ui/ModalTurma.test.tsx
+++ b/src/features/manage-turmas/ui/ModalTurma.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModalTurma } from './ModalTurma';
+import type { Turma } from '../../../entities/turmas/model/types';
+
+const turma: Turma = {
+  id: 'turma-1',
+  codigo: 'ANAT-01',
+  nome: 'Anatomia Sistemica',
+  semestre: '1',
+  ano: 2026,
+  descricao: 'Turma matutina',
+  status: 'ATIVA',
+  quantidadeAlunos: 15,
+  criadoEm: '2026-05-14T10:00:00.000Z',
+};
+
+describe('ModalTurma', () => {
+  const onClose = jest.fn();
+  const onSubmit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('nao deve renderizar quando estiver fechado', () => {
+    const { container } = render(
+      <ModalTurma
+        isOpen={false}
+        mode="create"
+        turma={null}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('deve manter botao de criar desabilitado ate preencher campos obrigatorios', async () => {
+    const user = userEvent.setup();
+    render(
+      <ModalTurma
+        isOpen={true}
+        mode="create"
+        turma={null}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const botaoSalvar = screen.getByRole('button', { name: /Criar turma/i });
+    expect(botaoSalvar).toBeDisabled();
+
+    await user.type(screen.getByLabelText('Codigo'), 'ANAT-01');
+    await user.type(screen.getByLabelText('Nome'), 'Anatomia Sistemica');
+    await user.type(screen.getByLabelText('Descricao'), 'Turma matutina');
+
+    expect(botaoSalvar).toBeEnabled();
+  });
+
+  it('deve enviar payload preenchido ao submeter criacao', async () => {
+    const user = userEvent.setup();
+    render(
+      <ModalTurma
+        isOpen={true}
+        mode="create"
+        turma={null}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(screen.getByLabelText('Codigo'), 'ANAT-01');
+    await user.type(screen.getByLabelText('Nome'), 'Anatomia Sistemica');
+    await user.clear(screen.getByLabelText('Ano'));
+    await user.type(screen.getByLabelText('Ano'), '2026');
+    await user.selectOptions(screen.getByLabelText('Semestre'), '2');
+    await user.type(screen.getByLabelText('Descricao'), 'Turma noturna');
+
+    await user.click(screen.getByRole('button', { name: /Criar turma/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      codigo: 'ANAT-01',
+      nome: 'Anatomia Sistemica',
+      ano: 2026,
+      semestre: '2',
+      descricao: 'Turma noturna',
+      status: 'ATIVA',
+    });
+  });
+
+  it('deve preencher os campos ao editar turma', () => {
+    render(
+      <ModalTurma
+        isOpen={true}
+        mode="edit"
+        turma={turma}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(screen.getByLabelText('Codigo')).toHaveValue('ANAT-01');
+    expect(screen.getByLabelText('Nome')).toHaveValue('Anatomia Sistemica');
+    expect(screen.getByLabelText('Ano')).toHaveValue(2026);
+    expect(screen.getByLabelText('Semestre')).toHaveValue('1');
+    expect(screen.getByLabelText('Descricao')).toHaveValue('Turma matutina');
+    expect(screen.getByLabelText('Status')).toHaveValue('ATIVA');
+  });
+
+  it('deve chamar onClose ao clicar em cancelar', async () => {
+    const user = userEvent.setup();
+    render(
+      <ModalTurma
+        isOpen={true}
+        mode="edit"
+        turma={turma}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Cancelar/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/manage-turmas/ui/ModalTurma.tsx
+++ b/src/features/manage-turmas/ui/ModalTurma.tsx
@@ -1,0 +1,205 @@
+import { useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import { Save, X } from 'lucide-react';
+import type { SalvarTurmaPayload, StatusTurma, Turma } from '../../../entities/turmas/model/types';
+
+interface ModalTurmaProps {
+  isOpen: boolean;
+  mode: 'create' | 'edit';
+  turma: Turma | null;
+  isLoading?: boolean;
+  onClose: () => void;
+  onSubmit: (payload: SalvarTurmaPayload) => void | Promise<void>;
+}
+
+const valoresIniciais = {
+  codigo: '',
+  nome: '',
+  ano: String(new Date().getFullYear()),
+  semestre: '1',
+  descricao: '',
+  status: 'ATIVA' as StatusTurma,
+};
+
+const obterValoresIniciais = (mode: 'create' | 'edit', turma: Turma | null) => {
+  if (mode === 'edit' && turma) {
+    return {
+      codigo: turma.codigo,
+      nome: turma.nome,
+      ano: String(turma.ano),
+      semestre: turma.semestre,
+      descricao: turma.descricao,
+      status: turma.status,
+    };
+  }
+
+  return valoresIniciais;
+};
+
+export const ModalTurma = ({
+  isOpen,
+  mode,
+  turma,
+  isLoading = false,
+  onClose,
+  onSubmit,
+}: ModalTurmaProps) => {
+  const estadoInicial = obterValoresIniciais(mode, turma);
+  const [codigo, setCodigo] = useState(estadoInicial.codigo);
+  const [nome, setNome] = useState(estadoInicial.nome);
+  const [ano, setAno] = useState(estadoInicial.ano);
+  const [semestre, setSemestre] = useState(estadoInicial.semestre);
+  const [descricao, setDescricao] = useState(estadoInicial.descricao);
+  const [status, setStatus] = useState<StatusTurma>(estadoInicial.status);
+
+  const anoNumerico = Number(ano);
+  const isFormValido = useMemo(() => (
+    codigo.trim().length > 0 &&
+    nome.trim().length > 0 &&
+    semestre.trim().length > 0 &&
+    Number.isInteger(anoNumerico) &&
+    anoNumerico > 0 &&
+    descricao.trim().length > 0
+  ), [anoNumerico, codigo, descricao, nome, semestre]);
+
+  if (!isOpen) return null;
+
+  const titulo = mode === 'create' ? 'Nova turma' : 'Editar turma';
+  const textoBotao = mode === 'create' ? 'Criar turma' : 'Salvar alteracoes';
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isFormValido || isLoading) return;
+
+    await onSubmit({
+      codigo: codigo.trim(),
+      nome: nome.trim(),
+      ano: anoNumerico,
+      semestre: semestre.trim(),
+      descricao: descricao.trim(),
+      status,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm">
+      <form
+        aria-modal="true"
+        role="dialog"
+        aria-labelledby="modal-turma-title"
+        onSubmit={handleSubmit}
+        className="w-full max-w-2xl rounded-xl bg-white p-6 shadow-xl"
+      >
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div>
+            <h3 id="modal-turma-title" className="text-lg font-bold text-gray-900">
+              {titulo}
+            </h3>
+            <p className="text-sm text-gray-500">
+              Informe os dados basicos da turma.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isLoading}
+            aria-label="Fechar modal de turma"
+            className="rounded-lg p-2 text-gray-500 hover:bg-gray-100 disabled:opacity-50"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+            Codigo
+            <input
+              value={codigo}
+              onChange={(event) => setCodigo(event.target.value)}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+              placeholder="ANAT-01"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+            Nome
+            <input
+              value={nome}
+              onChange={(event) => setNome(event.target.value)}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+              placeholder="Turma A"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+            Ano
+            <input
+              type="number"
+              min={2000}
+              value={ano}
+              onChange={(event) => setAno(event.target.value)}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+              placeholder="2026"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+            Semestre
+            <select
+              value={semestre}
+              onChange={(event) => setSemestre(event.target.value)}
+              className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+            >
+              <option value="1">1</option>
+              <option value="2">2</option>
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+            Status
+            <select
+              value={status}
+              onChange={(event) => setStatus(event.target.value as StatusTurma)}
+              className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+            >
+              <option value="ATIVA">Ativa</option>
+              <option value="INATIVA">Encerrada</option>
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 md:col-span-2">
+            Descricao
+            <textarea
+              value={descricao}
+              onChange={(event) => setDescricao(event.target.value)}
+              rows={4}
+              className="resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+              placeholder="Escopo, materia ou observacoes da turma"
+            />
+          </label>
+        </div>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isLoading}
+            className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+
+          <button
+            type="submit"
+            disabled={!isFormValido || isLoading}
+            className="flex items-center gap-2 rounded-lg bg-teal-400 px-4 py-2 text-sm font-bold text-teal-950 hover:bg-teal-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Save size={16} />
+            {isLoading ? 'Salvando...' : textoBotao}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/pages/turma/ui/TurmaPage.test.tsx
+++ b/src/pages/turma/ui/TurmaPage.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { TurmasPage } from './TurmaPage'; 
+
+jest.mock('../../../features/manage-turmas/ui/ListarTurmas', () => ({
+  ListaTurmas: () => <div data-testid="mock-lista-turmas">Mock da Lista de Turmas</div>,
+}));
+
+describe('TurmasPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve renderizar o título principal e a descrição da página', () => {
+    render(<TurmasPage />);
+
+    expect(screen.getByRole('heading', { name: 'Turmas' })).toBeInTheDocument();
+    
+    expect(screen.getByText('Gerencie suas turmas e alunos')).toBeInTheDocument();
+  });
+
+  it('deve renderizar o componente da feature ListaTurmas', () => {
+    render(<TurmasPage />);
+
+    expect(screen.getByTestId('mock-lista-turmas')).toBeInTheDocument();
+  });
+});

--- a/src/pages/turma/ui/TurmaPage.tsx
+++ b/src/pages/turma/ui/TurmaPage.tsx
@@ -1,0 +1,17 @@
+import { ListaTurmas } from '../../../features/manage-turmas/ui/ListarTurmas';
+
+export const TurmasPage = () => {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      
+      <main className="mx-auto max-w-7xl p-6">
+        <header className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Turmas</h1>
+          <p className="text-sm text-gray-500">Gerencie suas turmas e alunos</p>
+        </header>
+
+        <ListaTurmas />
+      </main>
+    </div>
+  );
+};

--- a/src/widgets/header/ui/Header.test.tsx
+++ b/src/widgets/header/ui/Header.test.tsx
@@ -107,4 +107,64 @@ describe('Header', () => {
       expect(screen.queryByRole('button', { name: /Fechar menu/i })).not.toBeInTheDocument();
     });
   });
+
+  it('navigates professors to the turmas page', async () => {
+    const testUser = userEvent.setup();
+
+    renderHeader({ user: makeUser('PROFESSOR'), isAuthenticated: true });
+
+    await testUser.click(screen.getByRole('button', { name: /Turmas/i }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/turmas');
+  });
+
+  it('renders the active turmas item for admin', () => {
+    renderHeader({ user: makeUser('ADMIN'), isAuthenticated: true }, '/turmas');
+
+    expect(screen.getByRole('button', { name: /Turmas/i })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('closes the mobile drawer when clicking the close button (X)', async () => {
+    const testUser = userEvent.setup();
+
+    renderHeader({ user: makeUser('STUDENT'), isAuthenticated: true });
+
+    await testUser.click(screen.getByRole('button', { name: /Abrir menu/i }));
+    expect(screen.getByRole('button', { name: /Fechar menu/i })).toBeInTheDocument();
+
+    await testUser.click(screen.getByRole('button', { name: /Fechar menu/i }));
+
+    expect(screen.queryByRole('button', { name: /Fechar menu/i })).not.toBeInTheDocument();
+  });
+
+  it('closes the mobile drawer automatically when a navigation item is selected', async () => {
+    const testUser = userEvent.setup();
+
+    renderHeader({ user: makeUser('STUDENT'), isAuthenticated: true });
+
+    await testUser.click(screen.getByRole('button', { name: /Abrir menu/i }));
+    expect(screen.getByRole('button', { name: /Fechar menu/i })).toBeInTheDocument();
+
+    const inicioButtons = screen.getAllByRole('button', { name: /Início/i });
+    await testUser.click(inicioButtons[1]);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Fechar menu/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('navigates to home when clicking the mobile logo', async () => {
+    const testUser = userEvent.setup();
+    
+    renderHeader({ user: makeUser('STUDENT'), isAuthenticated: true }, '/outra-rota');
+
+    const logos = screen.getAllByAltText('AnatoQuizUp');
+    const mobileLogoButton = logos[0].closest('button'); 
+    
+    if (mobileLogoButton) {
+      await testUser.click(mobileLogoButton);
+    }
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/home');
+  });
 });

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { LucideIcon } from "lucide-react";
-import { Eye, Home, LogOut, Menu, Users, X, Newspaper } from "lucide-react";
+import { Eye, Home, LogOut, Menu, Users, X, Newspaper, BookOpen } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../../../app/providers/AuthProvider";
 import logo from "../../../shared/assets/image/logo.png";
@@ -57,8 +57,8 @@ export const Header = () => {
       icon: Home,
       onSelect: () => navigate("/home"),
       isActive: isRouteActive("/home") || isRouteActive("/"),
-      // se role==professor -> ir para /professor/home, se role==student -> ir para /home
     };
+    
     const homeProfessorItem: NavItem = {
       key: "home",
       label: "Início",
@@ -69,7 +69,14 @@ export const Header = () => {
         isRouteActive("/home") ||
         isRouteActive("/"),
     };
-    // se role==professor -> ir para /professor/home, se role==student -> ir para /home
+
+    const turmasItem: NavItem = {
+      key: "turmas",
+      label: "Turmas",
+      icon: BookOpen,
+      onSelect: () => navigate("/turmas"),
+      isActive: location.pathname.startsWith("/turmas"),
+    };
 
     switch (role) {
       case "PROFESSOR":
@@ -93,6 +100,7 @@ export const Header = () => {
               location.pathname.startsWith("/professor/questoes") ||
               location.pathname.startsWith("/professor/criar-questao"),
           },
+          turmasItem, 
         ];
       case "ADMIN":
         return [
@@ -106,6 +114,7 @@ export const Header = () => {
               location.pathname.startsWith("/professor/questoes") ||
               location.pathname.startsWith("/professor/criar-questao"),
           },
+          turmasItem,
           {
             key: "admin-users",
             label: "Gerenciar Usuários",


### PR DESCRIPTION
## Descrição

Este PR implementa o fluxo de turmas no frontend do AnatoQuizUp.

Foram adicionadas as integrações necessárias para consumir as rotas de turmas, vínculos de alunos e usuários/alunos via BFF, seguindo a arquitetura:

```text
Frontend → BFF → Quiz-Service
Frontend → BFF → Backend
```

Principais entregas:

- integração com a API de turmas;
- integração com a API de usuários/alunos;
- criação de turma;
- edição de turma;
- exclusão de turma;
- listagem de turmas;
- filtro por busca, status, ano e semestre;
- modal de criação/edição de turma;
- modal de gerenciamento de alunos da turma;
- listagem dos alunos vinculados à turma;
- busca de alunos cadastrados;
- vínculo de aluno à turma;
- remoção de aluno da turma;
- feedback visual com toast local, sem adicionar nova dependência.

Também foram adicionados e atualizados testes para APIs, listagem e modais.

## Rastreabilidade

Issue(s) Relacionada(s):

- Closes: #43
- Closes: #44
- Relates to: #94
- Relates to: #70

Commits relacionados:

- af6108affc4b9294d5d6a7bcd66ed5eb13934ab3
- 313be52bb945026a0b19108fb3939e0142e6b31c
- 28ea9aa812fb47d65273646934444d9349ba88ca
- d6208c10d7aa2837e81afd2fc48ad9c68fa32fee

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Evidências (se aplicável)

<img width="1907" height="906" alt="image" src="https://github.com/user-attachments/assets/4d4ed4c8-64af-4b94-9659-e5d9c01216c4" />

<img width="1887" height="892" alt="image" src="https://github.com/user-attachments/assets/1a6cdd7f-9acb-4d83-8529-8a4ac817cd86" />

<img width="1905" height="902" alt="image" src="https://github.com/user-attachments/assets/9067c2e3-c47f-41b8-ba4d-8343cde68f50" />

<img width="1905" height="898" alt="image" src="https://github.com/user-attachments/assets/6e136917-5dab-4d22-ab15-e2cf265ea73f" />


Rotas consumidas pelo frontend:

```text
GET /turmas
POST /turmas
PATCH /turmas/:id
DELETE /turmas/:id
GET /turmas/:id/alunos
POST /turmas/:id/alunos
DELETE /turmas/:id/alunos/:alunoId
GET /usuarios/alunos
GET /usuarios?ids=id1,id2
```

Comandos executados:

```powershell
npm.cmd run lint
npm.cmd test -- --runInBand
npm.cmd run build
```

Resultados:

```text
Lint: passou sem erros
Test Suites: 42 passed, 42 total
Tests: 269 passed, 269 total
Build executado com sucesso
```


## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

O frontend faz a composição dos dados de alunos localmente:
- primeiro busca os vínculos da turma no Quiz-Service;
- depois busca os dados completos dos alunos no Backend por meio do BFF.

O BFF permanece como gateway/proxy simples, sem agregação de respostas.

O build precisou ser executado fora do sandbox local porque o Vite/Tailwind no Windows falhou com `spawn EPERM` ao carregar um binário nativo dentro do sandbox. Fora dele, o build compilou normalmente.