### PR TITLE
Feature/minhas turmas aluno

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ dev-stack: ## Imprime instrucoes para subir Backend + BFF + Web (3 terminais)
 	@echo "Para rodar a stack completa, abra 3 terminais e rode:"
 	@echo ""
 	@echo "  Terminal 1 (Backend):"
-	@echo "    cd ../2026-1-AnatoQuizUp-Backend && make dev"
+	@echo "    cd ../2026-1-AnatoQuizUp-Usuario-Service && make dev"
 	@echo ""
 	@echo "  Terminal 2 (BFF):"
 	@echo "    cd ../2026-1-AnatoQuizUp-API && make dev"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnatoQuizUp Web
 
-Frontend do projeto **AnatoQuizUp** — SPA em React + Vite + Tailwind. Consome **somente o BFF** (não acessa o Backend diretamente).
+Frontend do projeto **AnatoQuizUp** — SPA em React + Vite + Tailwind. Consome **somente o BFF** (não acessa o Usuario-Service nem o Quiz-Service diretamente).
 
 ## Stack
 
@@ -22,7 +22,7 @@ Frontend do projeto **AnatoQuizUp** — SPA em React + Vite + Tailwind. Consome 
 | GNU Make | opcional | Windows: `choco install make` |
 | BFF rodando em `localhost:4000` | — | siga o README de `2026-1-AnatoQuizUp-BFF` antes |
 
-> O Frontend **não fala** com o Backend diretamente. Você precisa do **BFF** rodando para fluxos autenticados funcionarem.
+> O Frontend **não fala** com Usuario-Service ou Quiz-Service diretamente. Você precisa do **BFF** rodando para fluxos autenticados funcionarem.
 
 ## Setup local — passo a passo
 
@@ -39,7 +39,7 @@ cd 2026-1-AnatoQuizUp-Web
 Copy-Item .env.example .env
 ```
 
-O `.env` deve apontar para o **BFF** (porta 4000), não para o Backend:
+O `.env` deve apontar para o **BFF** (porta 4000), não para os serviços de domínio:
 
 ```dotenv
 VITE_API_URL=http://localhost:4000/api/v1
@@ -57,13 +57,16 @@ npm run dev   # vite em http://localhost:5173
 
 ## Stack completa de desenvolvimento
 
-Para rodar a aplicação fim-a-fim, você precisa de **três processos** em três terminais:
+Para rodar a aplicação fim-a-fim, você precisa de **quatro processos** em quatro terminais:
 
 | Terminal | Repo | Porta | Comando |
 |---|---|---|---|
-| 1 | `2026-1-AnatoQuizUp-Backend` | 3333 | `npm run dev` (com Postgres no Docker) |
-| 2 | `2026-1-AnatoQuizUp-BFF` | 4000 | `npm run dev` |
-| 3 | `2026-1-AnatoQuizUp-Web` (este) | 5173 | `npm run dev` |
+| 1 | `2026-1-AnatoQuizUp-Usuario-Service` | 3333 | `npm run dev` (com Postgres `:5432` no Docker) |
+| 2 | `2026-1-AnatoQuizUp-Quiz-Service` | 3334 | `npm run dev` (com Postgres `:5433` + MinIO no Docker) |
+| 3 | `2026-1-AnatoQuizUp-BFF` | 4000 | `npm run dev` |
+| 4 | `2026-1-AnatoQuizUp-Web` (este) | 5173 | `npm run dev` |
+
+> Para passo-a-passo completo (envs, docker, smoke tests, troubleshooting), veja `2026-1-AnatoQuizUp-Doc/docs/contribuicao/setup-local.md`.
 
 Atalho prático no Web:
 
@@ -91,15 +94,28 @@ make clean      # apaga dist/ e coverage/
 src/
 ├── app/                     # configuração global, providers, rotas, layouts, estilos
 ├── pages/                   # telas acessadas por rota
+│   ├── aluno/{minhas-turmas, turma}/    # visão do aluno
+│   ├── forgot-password/, reset-password/
+│   ├── home/, homeAluno/, homeProfessor/
+│   ├── login/, register/, professor-register/
+│   ├── professor/criar-questao/
+│   ├── questao/                          # banco de questões
+│   └── turma/                            # gestão de turmas (professor/admin)
 ├── widgets/                 # blocos compostos de interface (header, sidebar, ...)
 ├── features/                # funcionalidades orientadas ao usuário
 │   ├── auth-by-credencials/
+│   ├── manage-questions/
+│   ├── manage-turmas/
+│   ├── minhas-turmas/
 │   ├── recover-password/
+│   ├── register-professor/
 │   └── register-student/
 ├── entities/                # modelos centrais do domínio
-│   └── user/
+│   ├── turmas/
+│   ├── user/                # ainda em inglês (débito conhecido)
+│   └── usuarios/
 ├── shared/                  # genérico/técnico
-│   ├── api/                 # httpClient (axios), services
+│   ├── api/                 # httpClient (axios, com refresh-token rotation), services
 │   ├── assets/
 │   ├── config/env.ts        # API_BASE_URL e USE_MOCKS
 │   ├── constants/
@@ -124,7 +140,7 @@ src/
 | Sintoma | Causa | Solução |
 |---|---|---|
 | Network error ao tentar login | BFF não está rodando | Suba o BFF em `localhost:4000` |
-| Login devolve 401 mesmo com credenciais certas | `JWT_SECRET_KEY` divergente entre BFF e Backend | Confira que estão idênticos nos dois `.env` |
+| Login devolve 401 mesmo com credenciais certas | `JWT_SECRET_KEY` divergente entre BFF e Usuario-Service | Confira que estão idênticos nos dois `.env` |
 | `VITE_API_URL` mudou mas o front continua chamando URL antiga | Vite cacheia a build | Stop `npm run dev`, apague `node_modules/.vite/` e suba de novo |
 | Erro 503 com `IA_INDISPONIVEL` em `/ia/...` | Esperado | AI Service ainda não foi implementado nesta release; mantenha placeholders |
 | CORS bloqueando localhost | `CORS_ORIGINS` do BFF não inclui `http://localhost:5173` | Editar `.env` do BFF |

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -73,6 +73,14 @@ jest.mock('../pages/turma/ui/TurmaPage', () => ({
   TurmasPage: () => <main>Turmas route</main>,
 }));
 
+jest.mock('../pages/aluno/minhas-turmas', () => ({
+  MinhasTurmasAlunoPage: () => <main>Minhas turmas aluno route</main>,
+}));
+
+jest.mock('../pages/aluno/turma', () => ({
+  TurmaDetalheAlunoPage: () => <main>Detalhe turma aluno route</main>,
+}));
+
 const renderAppAt = (path: string) => {
   window.history.pushState({}, '', path);
   return render(<App />);

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -12,6 +12,8 @@ import { HomeProfessorPage } from "../pages/homeProfessor";
 import { QuestionsPage } from "../pages/questao";
 import { CreateQuestionPage } from "../pages/professor/criar-questao";
 import { TurmasPage } from "../pages/turma/ui/TurmaPage";
+import { MinhasTurmasAlunoPage } from "../pages/aluno/minhas-turmas";
+import { TurmaDetalheAlunoPage } from "../pages/aluno/turma";
 
 export const AppRouter = () => {
   return (
@@ -32,13 +34,31 @@ export const AppRouter = () => {
           </ProtectedRoute>
         }
       >
-        <Route 
+        <Route
           path="/aluno/home"
           element={
             <ProtectedRoute allowedRoles={['STUDENT']}>
               <HomeAlunoPage />
             </ProtectedRoute>
-          } 
+          }
+        />
+
+        <Route
+          path="/aluno/turmas"
+          element={
+            <ProtectedRoute allowedRoles={['STUDENT']}>
+              <MinhasTurmasAlunoPage />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/aluno/turmas/:id"
+          element={
+            <ProtectedRoute allowedRoles={['STUDENT']}>
+              <TurmaDetalheAlunoPage />
+            </ProtectedRoute>
+          }
         />
 
         <Route 

--- a/src/entities/usuarios/api/usuarioApi.test.ts
+++ b/src/entities/usuarios/api/usuarioApi.test.ts
@@ -1,5 +1,5 @@
 import { httpClient } from '../../../shared/api/httpClient';
-import { buscarAlunos, buscarUsuariosPorIds } from './usuarioApi';
+import { buscarAlunos, buscarUsuarioPorId, buscarUsuariosPorIds } from './usuarioApi';
 
 jest.mock('../../../shared/api/httpClient', () => ({
   httpClient: {
@@ -57,5 +57,21 @@ describe('usuarioApi', () => {
 
     expect(httpClient.get).not.toHaveBeenCalled();
     expect(resultado).toEqual([]);
+  });
+
+  it('deve buscar usuario publico por id', async () => {
+    const usuarioPublico = {
+      id: 'prof-1',
+      nome: 'Maria Souza',
+      papel: 'PROFESSOR',
+    };
+    (httpClient.get as jest.Mock).mockResolvedValue({
+      data: { mensagem: 'Usuario encontrado', dados: usuarioPublico },
+    });
+
+    const resultado = await buscarUsuarioPorId('prof-1');
+
+    expect(httpClient.get).toHaveBeenCalledWith('/usuarios/prof-1');
+    expect(resultado).toEqual(usuarioPublico);
   });
 });

--- a/src/entities/usuarios/api/usuarioApi.ts
+++ b/src/entities/usuarios/api/usuarioApi.ts
@@ -1,5 +1,5 @@
 import { httpClient } from '../../../shared/api/httpClient';
-import type { ResultadoBuscaAlunos, UsuarioResumo } from '../model/types';
+import type { ResultadoBuscaAlunos, UsuarioPublico, UsuarioResumo } from '../model/types';
 
 type RespostaApi<T> = {
   mensagem?: string;
@@ -30,5 +30,10 @@ export const buscarUsuariosPorIds = async (ids: string[]) => {
     },
   });
 
+  return response.data.dados;
+};
+
+export const buscarUsuarioPorId = async (id: string): Promise<UsuarioPublico> => {
+  const response = await httpClient.get<RespostaApi<UsuarioPublico>>(`/usuarios/${id}`);
   return response.data.dados;
 };

--- a/src/entities/usuarios/model/types.ts
+++ b/src/entities/usuarios/model/types.ts
@@ -24,3 +24,9 @@ export interface ResultadoBuscaAlunos {
   dados: UsuarioResumo[];
   metadados: MetadadosPaginacao;
 }
+
+export interface UsuarioPublico {
+  id: string;
+  nome: string;
+  papel: PerfilUsuario;
+}

--- a/src/features/minhas-turmas/index.ts
+++ b/src/features/minhas-turmas/index.ts
@@ -1,0 +1,1 @@
+export { MinhasTurmas } from './ui/MinhasTurmas';

--- a/src/features/minhas-turmas/index.ts
+++ b/src/features/minhas-turmas/index.ts
@@ -1,1 +1,2 @@
 export { MinhasTurmas } from './ui/MinhasTurmas';
+export { DetalheTurma } from './ui/DetalheTurma';

--- a/src/features/minhas-turmas/ui/DetalheTurma.test.tsx
+++ b/src/features/minhas-turmas/ui/DetalheTurma.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+
+import { DetalheTurma } from './DetalheTurma';
+import { httpClient } from '../../../shared/api/httpClient';
+import { buscarUsuarioPorId } from '../../../entities/usuarios/api/usuarioApi';
+
+jest.mock('../../../shared/api/httpClient', () => ({
+  httpClient: {
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('../../../entities/usuarios/api/usuarioApi', () => ({
+  buscarUsuarioPorId: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const original = jest.requireActual('react-router-dom');
+  return {
+    ...original,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ id: 'turma-1' }),
+  };
+});
+
+const turmaApiMock = {
+  id: 'turma-1',
+  codigo: 'ANAT-01',
+  nome: 'Anatomia Sistemica',
+  semestre: '1',
+  ano: 2026,
+  descricao: 'Estudo da estrutura do corpo humano.',
+  status: 'ATIVA',
+  quantidadeAlunos: 12,
+  criadoEm: '2026-03-01T10:00:00.000Z',
+  professorId: 'prof-1',
+};
+
+const usuarioPublicoMock = {
+  id: 'prof-1',
+  nome: 'Dra. Maria Souza',
+  papel: 'PROFESSOR' as const,
+};
+
+const renderComponente = () =>
+  render(
+    <MemoryRouter>
+      <DetalheTurma />
+    </MemoryRouter>,
+  );
+
+describe('DetalheTurma Feature', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve renderizar nome, descricao e professor da turma', async () => {
+    (httpClient.get as jest.Mock).mockResolvedValue({
+      data: { dados: turmaApiMock },
+    });
+    (buscarUsuarioPorId as jest.Mock).mockResolvedValue(usuarioPublicoMock);
+
+    renderComponente();
+
+    expect(await screen.findByText('Anatomia Sistemica')).toBeInTheDocument();
+    expect(screen.getByText('2026.1')).toBeInTheDocument();
+    expect(
+      screen.getByText('Estudo da estrutura do corpo humano.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Dra. Maria Souza')).toBeInTheDocument();
+
+    expect(httpClient.get).toHaveBeenCalledWith('/turmas/turma-1');
+    expect(buscarUsuarioPorId).toHaveBeenCalledWith('prof-1');
+  });
+
+  it('deve exibir fallback quando nao for possivel obter o professor', async () => {
+    (httpClient.get as jest.Mock).mockResolvedValue({
+      data: { dados: turmaApiMock },
+    });
+    (buscarUsuarioPorId as jest.Mock).mockRejectedValue(new Error('falha'));
+
+    renderComponente();
+
+    expect(await screen.findByText('Anatomia Sistemica')).toBeInTheDocument();
+    expect(screen.getByText('Professor não disponível')).toBeInTheDocument();
+  });
+
+  it('deve exibir estado nao encontrada quando a turma retornar 404', async () => {
+    const erro404 = Object.assign(new Error('not found'), {
+      isAxiosError: true,
+      response: { status: 404 },
+    });
+    jest.spyOn(axios, 'isAxiosError').mockReturnValue(true);
+    (httpClient.get as jest.Mock).mockRejectedValue(erro404);
+
+    renderComponente();
+
+    expect(await screen.findByText('Turma não encontrada.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Esta turma não existe ou você não está vinculado a ela.'),
+    ).toBeInTheDocument();
+  });
+
+  it('deve exibir estado de erro generico quando a chamada falhar com erro nao 404', async () => {
+    jest.spyOn(axios, 'isAxiosError').mockReturnValue(false);
+    (httpClient.get as jest.Mock).mockRejectedValue(new Error('falha 500'));
+
+    renderComponente();
+
+    expect(
+      await screen.findByText('Não foi possível carregar os detalhes da turma.'),
+    ).toBeInTheDocument();
+  });
+
+  it('deve navegar de volta para listagem ao clicar em voltar', async () => {
+    const user = userEvent.setup();
+    (httpClient.get as jest.Mock).mockResolvedValue({
+      data: { dados: turmaApiMock },
+    });
+    (buscarUsuarioPorId as jest.Mock).mockResolvedValue(usuarioPublicoMock);
+
+    renderComponente();
+
+    await screen.findByText('Anatomia Sistemica');
+
+    await user.click(
+      screen.getAllByRole('button', { name: /Voltar para minhas turmas/i })[0],
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/aluno/turmas');
+    });
+  });
+});

--- a/src/features/minhas-turmas/ui/DetalheTurma.test.tsx
+++ b/src/features/minhas-turmas/ui/DetalheTurma.test.tsx
@@ -59,6 +59,11 @@ describe('DetalheTurma Feature', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    // Restaura jest.spyOn (ex.: axios.isAxiosError) para nao vazar entre testes.
+    jest.restoreAllMocks();
+  });
+
   it('deve renderizar nome, descricao e professor da turma', async () => {
     (httpClient.get as jest.Mock).mockResolvedValue({
       data: { dados: turmaApiMock },

--- a/src/features/minhas-turmas/ui/DetalheTurma.tsx
+++ b/src/features/minhas-turmas/ui/DetalheTurma.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, BookOpen, GraduationCap, UserCircle2 } from 'lucide-react';
+
+import { httpClient } from '../../../shared/api/httpClient';
+import type { Turma } from '../../../entities/turmas/model/types';
+import { buscarUsuarioPorId } from '../../../entities/usuarios/api/usuarioApi';
+import type { UsuarioPublico } from '../../../entities/usuarios/model/types';
+
+type EstadoDetalhe = 'carregando' | 'sucesso' | 'erro' | 'nao-encontrada';
+
+interface TurmaApi extends Omit<Turma, 'quantidadeAlunos'> {
+  quantidadeAlunos?: number;
+  _count?: { alunos?: number };
+  professorId: string;
+}
+
+interface RespostaApi<T> {
+  mensagem?: string;
+  dados: T;
+}
+
+const normalizarTurma = (turma: TurmaApi): Turma & { professorId: string } => {
+  const { _count, quantidadeAlunos, ...resto } = turma;
+
+  return {
+    ...resto,
+    quantidadeAlunos: quantidadeAlunos ?? _count?.alunos ?? 0,
+  };
+};
+
+const buscarTurma = async (id: string) => {
+  const response = await httpClient.get<RespostaApi<TurmaApi>>(`/turmas/${id}`);
+  return normalizarTurma(response.data.dados);
+};
+
+const ehErroNaoEncontrado = (erro: unknown) => {
+  return axios.isAxiosError(erro) && erro.response?.status === 404;
+};
+
+const EstadoCarregando = () => (
+  <div
+    role="status"
+    aria-live="polite"
+    className="flex min-h-[200px] items-center justify-center"
+  >
+    <span className="animate-pulse text-sm text-gray-500">Carregando detalhes...</span>
+  </div>
+);
+
+interface EstadoNaoEncontradaProps {
+  onVoltar: () => void;
+}
+
+const EstadoNaoEncontrada = ({ onVoltar }: EstadoNaoEncontradaProps) => (
+  <div className="flex min-h-[280px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-gray-300 bg-white p-8 text-center">
+    <h2 className="text-lg font-bold text-[#0A1128]">Turma não encontrada.</h2>
+    <p className="max-w-md text-sm text-gray-500">
+      Esta turma não existe ou você não está vinculado a ela.
+    </p>
+    <button
+      type="button"
+      onClick={onVoltar}
+      className="mt-2 inline-flex items-center gap-2 rounded-lg bg-teal-400 px-4 py-2 text-sm font-bold text-teal-950 transition-colors hover:bg-teal-500"
+    >
+      <ArrowLeft size={16} />
+      Voltar para minhas turmas
+    </button>
+  </div>
+);
+
+const EstadoErro = () => (
+  <div
+    role="alert"
+    className="flex min-h-[200px] flex-col items-center justify-center gap-2 rounded-2xl border border-red-100 bg-red-50 p-6 text-center"
+  >
+    <p className="text-base font-semibold text-red-800">
+      Não foi possível carregar os detalhes da turma.
+    </p>
+    <p className="text-sm text-red-700">Tente novamente em alguns instantes.</p>
+  </div>
+);
+
+export const DetalheTurma = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const [turma, setTurma] = useState<(Turma & { professorId: string }) | null>(null);
+  const [professor, setProfessor] = useState<UsuarioPublico | null>(null);
+  const [estado, setEstado] = useState<EstadoDetalhe>(id ? 'carregando' : 'nao-encontrada');
+
+  useEffect(() => {
+    if (!id) return undefined;
+
+    let cancelado = false;
+
+    const carregar = async () => {
+      try {
+        const turmaCarregada = await buscarTurma(id);
+        if (cancelado) return;
+
+        setTurma(turmaCarregada);
+
+        try {
+          const professorCarregado = await buscarUsuarioPorId(turmaCarregada.professorId);
+          if (!cancelado) setProfessor(professorCarregado);
+        } catch {
+          if (!cancelado) setProfessor(null);
+        }
+
+        if (!cancelado) setEstado('sucesso');
+      } catch (erro) {
+        if (cancelado) return;
+        setEstado(ehErroNaoEncontrado(erro) ? 'nao-encontrada' : 'erro');
+      }
+    };
+
+    void carregar();
+
+    return () => {
+      cancelado = true;
+    };
+  }, [id]);
+
+  const voltar = () => navigate('/aluno/turmas');
+
+  return (
+    <section className="mx-auto w-full max-w-3xl px-4 py-6 md:px-8 md:py-10">
+      <button
+        type="button"
+        onClick={voltar}
+        className="mb-6 inline-flex items-center gap-2 text-sm font-semibold text-teal-700 transition-colors hover:text-teal-900"
+      >
+        <ArrowLeft size={16} />
+        Voltar para minhas turmas
+      </button>
+
+      {estado === 'carregando' && <EstadoCarregando />}
+      {estado === 'erro' && <EstadoErro />}
+      {estado === 'nao-encontrada' && <EstadoNaoEncontrada onVoltar={voltar} />}
+
+      {estado === 'sucesso' && turma && (
+        <article className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm md:p-8">
+          <header className="mb-6 flex items-start gap-4">
+            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-teal-100 text-teal-700">
+              <BookOpen size={26} />
+            </span>
+            <div>
+              <h1 className="text-2xl font-black text-[#0A1128] md:text-3xl">{turma.nome}</h1>
+              <p className="mt-1 text-sm text-gray-500 md:text-base">
+                {turma.ano}.{turma.semestre}
+              </p>
+            </div>
+          </header>
+
+          <section className="mb-6">
+            <h2 className="mb-2 flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-500">
+              <GraduationCap size={16} />
+              Descrição da matéria
+            </h2>
+            <p className="text-base text-[#0A1128]">{turma.descricao}</p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-500">
+              <UserCircle2 size={16} />
+              Professor responsável
+            </h2>
+            <p className="text-base text-[#0A1128]">
+              {professor?.nome ?? 'Professor não disponível'}
+            </p>
+          </section>
+        </article>
+      )}
+    </section>
+  );
+};

--- a/src/features/minhas-turmas/ui/MinhasTurmas.test.tsx
+++ b/src/features/minhas-turmas/ui/MinhasTurmas.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import { MinhasTurmas } from './MinhasTurmas';
+import { listarTurmas } from '../../../entities/turmas/api/turmaApi';
+import type { Turma } from '../../../entities/turmas/model/types';
+
+jest.mock('../../../entities/turmas/api/turmaApi', () => ({
+  listarTurmas: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const original = jest.requireActual('react-router-dom');
+  return {
+    ...original,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const turmasMock: Turma[] = [
+  {
+    id: 'turma-1',
+    codigo: 'ANAT-01',
+    nome: 'Anatomia Sistemica',
+    semestre: '1',
+    ano: 2026,
+    descricao: 'Turma matutina',
+    status: 'ATIVA',
+    quantidadeAlunos: 0,
+    criadoEm: '2026-03-01T10:00:00.000Z',
+  },
+  {
+    id: 'turma-2',
+    codigo: 'NEURO-02',
+    nome: 'Neuroanatomia',
+    semestre: '2',
+    ano: 2025,
+    descricao: 'Turma noturna',
+    status: 'ATIVA',
+    quantidadeAlunos: 0,
+    criadoEm: '2025-08-01T10:00:00.000Z',
+  },
+];
+
+const renderComponente = () =>
+  render(
+    <MemoryRouter>
+      <MinhasTurmas />
+    </MemoryRouter>,
+  );
+
+describe('MinhasTurmas Feature', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve exibir estado de carregamento enquanto busca turmas', () => {
+    (listarTurmas as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    renderComponente();
+
+    expect(screen.getByRole('status')).toHaveTextContent('Carregando turmas...');
+  });
+
+  it('deve renderizar lista de turmas em formato de cards', async () => {
+    (listarTurmas as jest.Mock).mockResolvedValue(turmasMock);
+
+    renderComponente();
+
+    expect(await screen.findByText('Anatomia Sistemica')).toBeInTheDocument();
+    expect(screen.getByText('Neuroanatomia')).toBeInTheDocument();
+    expect(screen.getByText('2026.1')).toBeInTheDocument();
+    expect(screen.getByText('2025.2')).toBeInTheDocument();
+  });
+
+  it('deve exibir estado vazio quando aluno nao estiver em nenhuma turma', async () => {
+    (listarTurmas as jest.Mock).mockResolvedValue([]);
+
+    renderComponente();
+
+    expect(
+      await screen.findByText('Você ainda não foi adicionado a nenhuma turma.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Aguarde o convite do seu professor/i),
+    ).toBeInTheDocument();
+  });
+
+  it('deve exibir mensagem de erro quando a chamada falhar', async () => {
+    (listarTurmas as jest.Mock).mockRejectedValue(new Error('falha'));
+
+    renderComponente();
+
+    expect(
+      await screen.findByText('Não foi possível carregar suas turmas.'),
+    ).toBeInTheDocument();
+  });
+
+  it('deve navegar para o detalhe ao clicar em um card de turma', async () => {
+    const user = userEvent.setup();
+    (listarTurmas as jest.Mock).mockResolvedValue(turmasMock);
+
+    renderComponente();
+
+    const card = (await screen.findByText('Anatomia Sistemica')).closest('button');
+    expect(card).not.toBeNull();
+
+    await user.click(card!);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/aluno/turmas/turma-1');
+    });
+  });
+});

--- a/src/features/minhas-turmas/ui/MinhasTurmas.tsx
+++ b/src/features/minhas-turmas/ui/MinhasTurmas.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { BookOpen, ChevronRight, Inbox } from 'lucide-react';
+
+import { listarTurmas } from '../../../entities/turmas/api/turmaApi';
+import type { Turma } from '../../../entities/turmas/model/types';
+
+type Estado = 'carregando' | 'vazio' | 'sucesso' | 'erro';
+
+interface TurmaCardProps {
+  turma: Turma;
+  onClick: () => void;
+}
+
+const TurmaCard = ({ turma, onClick }: TurmaCardProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="group flex w-full flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-5 text-left shadow-sm transition-all hover:-translate-y-1 hover:border-teal-300 hover:shadow-md focus:-translate-y-1 focus:border-teal-400 focus:shadow-md"
+  >
+    <div className="flex items-start justify-between gap-3">
+      <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-teal-100 text-teal-700">
+        <BookOpen size={22} />
+      </span>
+      <ChevronRight
+        size={20}
+        className="text-gray-300 transition-colors group-hover:text-teal-500"
+      />
+    </div>
+    <div>
+      <h3 className="text-lg font-bold text-[#0A1128]">{turma.nome}</h3>
+      <p className="mt-1 text-sm text-gray-500">{turma.ano}.{turma.semestre}</p>
+    </div>
+  </button>
+);
+
+const EstadoCarregando = () => (
+  <div
+    role="status"
+    aria-live="polite"
+    className="flex min-h-[200px] items-center justify-center"
+  >
+    <span className="animate-pulse text-sm text-gray-500">Carregando turmas...</span>
+  </div>
+);
+
+const EstadoErro = () => (
+  <div
+    role="alert"
+    className="flex min-h-[200px] flex-col items-center justify-center gap-2 rounded-2xl border border-red-100 bg-red-50 p-6 text-center"
+  >
+    <p className="text-base font-semibold text-red-800">
+      Não foi possível carregar suas turmas.
+    </p>
+    <p className="text-sm text-red-700">Tente novamente em alguns instantes.</p>
+  </div>
+);
+
+const EstadoVazio = () => (
+  <div className="flex min-h-[280px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-gray-300 bg-white p-8 text-center">
+    <span className="flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 text-teal-600">
+      <Inbox size={32} />
+    </span>
+    <h2 className="text-lg font-bold text-[#0A1128]">
+      Você ainda não foi adicionado a nenhuma turma.
+    </h2>
+    <p className="max-w-md text-sm text-gray-500">
+      Aguarde o convite do seu professor. Assim que você for vinculado a uma turma,
+      ela aparecerá aqui.
+    </p>
+  </div>
+);
+
+export const MinhasTurmas = () => {
+  const navigate = useNavigate();
+  const [turmas, setTurmas] = useState<Turma[]>([]);
+  const [estado, setEstado] = useState<Estado>('carregando');
+
+  useEffect(() => {
+    let cancelado = false;
+
+    listarTurmas()
+      .then((dados) => {
+        if (cancelado) return;
+        setTurmas(dados);
+        setEstado(dados.length === 0 ? 'vazio' : 'sucesso');
+      })
+      .catch(() => {
+        if (cancelado) return;
+        setEstado('erro');
+      });
+
+    return () => {
+      cancelado = true;
+    };
+  }, []);
+
+  return (
+    <section className="mx-auto w-full max-w-6xl px-4 py-6 md:px-8 md:py-10">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-black text-[#0A1128] md:text-3xl">Minhas Turmas</h1>
+        <p className="mt-1 text-sm text-gray-500 md:text-base">
+          Visualize as turmas em que você está matriculado.
+        </p>
+      </header>
+
+      {estado === 'carregando' && <EstadoCarregando />}
+      {estado === 'erro' && <EstadoErro />}
+      {estado === 'vazio' && <EstadoVazio />}
+      {estado === 'sucesso' && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {turmas.map((turma) => (
+            <TurmaCard
+              key={turma.id}
+              turma={turma}
+              onClick={() => navigate(`/aluno/turmas/${turma.id}`)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/pages/aluno/minhas-turmas/index.ts
+++ b/src/pages/aluno/minhas-turmas/index.ts
@@ -1,0 +1,1 @@
+export { MinhasTurmasAlunoPage } from './ui/MinhasTurmasAlunoPage';

--- a/src/pages/aluno/minhas-turmas/ui/MinhasTurmasAlunoPage.test.tsx
+++ b/src/pages/aluno/minhas-turmas/ui/MinhasTurmasAlunoPage.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../../../../features/minhas-turmas', () => ({
+  MinhasTurmas: () => <main>Minhas turmas feature</main>,
+}));
+
+import { MinhasTurmasAlunoPage } from './MinhasTurmasAlunoPage';
+
+describe('MinhasTurmasAlunoPage', () => {
+  it('renderiza a feature de Minhas Turmas', () => {
+    render(<MinhasTurmasAlunoPage />);
+
+    expect(screen.getByText('Minhas turmas feature')).toBeInTheDocument();
+  });
+});

--- a/src/pages/aluno/minhas-turmas/ui/MinhasTurmasAlunoPage.tsx
+++ b/src/pages/aluno/minhas-turmas/ui/MinhasTurmasAlunoPage.tsx
@@ -1,0 +1,3 @@
+import { MinhasTurmas } from '../../../../features/minhas-turmas';
+
+export const MinhasTurmasAlunoPage = () => <MinhasTurmas />;

--- a/src/pages/aluno/turma/index.ts
+++ b/src/pages/aluno/turma/index.ts
@@ -1,0 +1,1 @@
+export { TurmaDetalheAlunoPage } from './ui/TurmaDetalheAlunoPage';

--- a/src/pages/aluno/turma/ui/TurmaDetalheAlunoPage.test.tsx
+++ b/src/pages/aluno/turma/ui/TurmaDetalheAlunoPage.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../../../../features/minhas-turmas', () => ({
+  DetalheTurma: () => <main>Detalhe turma feature</main>,
+}));
+
+import { TurmaDetalheAlunoPage } from './TurmaDetalheAlunoPage';
+
+describe('TurmaDetalheAlunoPage', () => {
+  it('renderiza a feature de detalhe da turma', () => {
+    render(<TurmaDetalheAlunoPage />);
+
+    expect(screen.getByText('Detalhe turma feature')).toBeInTheDocument();
+  });
+});

--- a/src/pages/aluno/turma/ui/TurmaDetalheAlunoPage.tsx
+++ b/src/pages/aluno/turma/ui/TurmaDetalheAlunoPage.tsx
@@ -1,0 +1,3 @@
+import { DetalheTurma } from '../../../../features/minhas-turmas';
+
+export const TurmaDetalheAlunoPage = () => <DetalheTurma />;

--- a/src/pages/aluno/turma/ui/TurmaDetalheAlunoPage.tsx
+++ b/src/pages/aluno/turma/ui/TurmaDetalheAlunoPage.tsx
@@ -1,3 +1,9 @@
+import { useParams } from 'react-router-dom';
+
 import { DetalheTurma } from '../../../../features/minhas-turmas';
 
-export const TurmaDetalheAlunoPage = () => <DetalheTurma />;
+export const TurmaDetalheAlunoPage = () => {
+  const { id } = useParams<{ id: string }>();
+  // key={id} forca remontagem ao trocar de turma, evitando flash de dados antigos.
+  return <DetalheTurma key={id} />;
+};

--- a/src/widgets/header/ui/Header.test.tsx
+++ b/src/widgets/header/ui/Header.test.tsx
@@ -124,6 +124,27 @@ describe('Header', () => {
     expect(screen.getByRole('button', { name: /Turmas/i })).toHaveAttribute('aria-current', 'page');
   });
 
+  it('navigates students to minhas turmas page', async () => {
+    const testUser = userEvent.setup();
+
+    renderHeader({ user: makeUser('STUDENT'), isAuthenticated: true });
+
+    await testUser.click(screen.getByRole('button', { name: /Minhas Turmas/i }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/aluno/turmas');
+  });
+
+  it('renders the active minhas turmas item for student on detail route', () => {
+    renderHeader(
+      { user: makeUser('STUDENT'), isAuthenticated: true },
+      '/aluno/turmas/turma-1',
+    );
+
+    expect(
+      screen.getByRole('button', { name: /Minhas Turmas/i }),
+    ).toHaveAttribute('aria-current', 'page');
+  });
+
   it('closes the mobile drawer when clicking the close button (X)', async () => {
     const testUser = userEvent.setup();
 

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -69,14 +69,6 @@ export const Header = () => {
         isRouteActive("/home") ||
         isRouteActive("/"),
     };
-
-    const studentQuestaoItem: NavItem = {
-      key: "aluno-questoes",
-      label: "Questões",
-      icon: Newspaper,
-      onSelect: () => navigate("/aluno/quiz/escolha"),
-      isActive: location.pathname.startsWith("/aluno/quiz"),
-    }
     
     const turmasItem: NavItem = {
       key: "turmas",

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -78,6 +78,14 @@ export const Header = () => {
       isActive: location.pathname.startsWith("/turmas"),
     };
 
+    const minhasTurmasAlunoItem: NavItem = {
+      key: "minhas-turmas",
+      label: "Minhas Turmas",
+      icon: BookOpen,
+      onSelect: () => navigate("/aluno/turmas"),
+      isActive: location.pathname.startsWith("/aluno/turmas"),
+    };
+
     switch (role) {
       case "PROFESSOR":
         return [
@@ -125,7 +133,7 @@ export const Header = () => {
         ];
       case "STUDENT":
       default:
-        return [homeItem];
+        return [homeItem, minhasTurmasAlunoItem];
     }
   };
 

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -102,6 +102,7 @@ export const Header = () => {
       icon: BookOpen,
       onSelect: () => navigate("/aluno/turmas"),
       isActive: location.pathname.startsWith("/aluno/turmas"),
+    }
       
     const listasItem: NavItem = {
       key: "listas",


### PR DESCRIPTION
## Descrição

Este PR completa o ciclo de gestão acadêmica do AnatoQuizUp implementando a visão do **aluno** sobre as turmas em que ele está vinculado. O professor já podia criar turmas e vincular alunos; agora o aluno consegue **ver suas turmas** e **abrir o detalhe** de cada uma com nome do professor responsável, descrição da disciplina, semestre e ano.

A entrega abrange **4 repositórios de código + 1 repositório de documentação**, todos integrados:

- **Web** (este PR) — feature `minhas-turmas` com listagem em grid, detalhe, empty state, responsividade desktop/mobile, item de menu lateral, testes e cobertura ≥ 85%.
- **BFF** — testes de integração validando proxy de `/turmas` e `/usuarios/:id` com JWT de aluno e injeção do header `X-User-Papel: ALUNO`.
- **Quiz-Service** — abertura controlada das rotas `GET /turmas` e `GET /turmas/:id` para o papel ALUNO, com filtro por papel resolvido no service (aluno vê apenas turmas vinculadas e ATIVAs; `?status=` rejeitado com 400 para aluno; turma não vinculada retorna 404 em vez de 403 para não vazar existência).
- **Usuario-Service** — novo endpoint `GET /api/v1/usuarios/:id` aberto a qualquer papel autenticado, com payload mínimo `{ id, nome, papel }`. É a rota usada pelo Web para resolver o nome do professor na tela de detalhe.
- **Doc** — atualização da documentação de arquitetura, contratos de API, visões e setup local; ajustes de nomenclatura (`Backend` → `Usuario-Service`).

> **Por que essa US importa:** o fluxo de gestão de turmas pelo professor estava cego do lado do aluno. Sem essa visão, o aluno cadastrado não tinha como confirmar que foi de fato vinculado a uma turma, nem ver o contexto pedagógico das disciplinas em que está matriculado. Essa entrega fecha o loop.

---

## Rastreabilidade

**Issue:**

- Closes: #<numero-da-issue-da-US>

**PRs cross-repo:**

- `2026-1-AnatoQuizUp-Web` (este) → branch `feature/minhas-turmas-aluno`
- `2026-1-AnatoQuizUp-BFF` → branch `feature/minhas-turmas-aluno`
- `2026-1-AnatoQuizUp-Quiz-Service` → branch `feature/minhas-turmas-aluno`
- `2026-1-AnatoQuizUp-Usuario-Service` → branch `feature/minhas-turmas-aluno`
- `2026-1-AnatoQuizUp-Doc` → branch `feature/minhas-turmas-aluno`

> A ordem de merge sugerida é **Usuario-Service → Quiz-Service → BFF → Web → Doc**. O Web depende do endpoint `GET /usuarios/:id` (Usuario-Service) e da liberação de papel nas rotas de turma (Quiz-Service).

**Commits deste PR (Web):**

- `b588234` — feat(usuarios): adiciona busca publica de usuario por id
- `488f8d9` — feat(minhas-turmas): adiciona listagem de turmas do aluno
- `9f8036a` — feat(minhas-turmas): adiciona detalhamento de turma do aluno
- `7a6c1ea` — feat(aluno): adiciona paginas e rotas de minhas turmas
- `06c9e37` — feat(header): adiciona item de navegacao para minhas turmas do aluno
- `53ecdc1` — chore: Atualiza readme
- `c5277d4` — fix(minhas-turmas): remonta DetalheTurma ao trocar de turma
- `10293bc` — test(minhas-turmas): restaura mocks do axios apos cada teste

---

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [x] Documentação
- [x] Testes

---

## Arquitetura do Fluxo

```
Browser
   |
   v
Web (React/Vite, este repo)
   |  Bearer JWT
   v
BFF (Express, proxy)
   |  Bearer JWT + X-Internal-Token + X-User-Papel: ALUNO
   |
   +---> Quiz-Service.GET /api/v1/turmas         (lista vinculadas + ATIVAs)
   +---> Quiz-Service.GET /api/v1/turmas/:id     (404 se nao vinculado)
   +---> Usuario-Service.GET /api/v1/usuarios/:id (resolve nome do professor)
```

- O Web nunca chama Usuario-Service ou Quiz-Service diretamente.
- O BFF valida JWT na borda e injeta `X-Internal-Token` + headers de usuário.
- Cada serviço de domínio **revalida** o JWT localmente. Headers `X-User-*` são informativos, não substituem o JWT como fonte de autorização.

---

## Mudanças por Repositório

### Web (este PR)

**Novo:**

- `features/minhas-turmas/` — feature com `MinhasTurmas.tsx` (lista) e `DetalheTurma.tsx` (detalhe).
- `pages/aluno/minhas-turmas/` e `pages/aluno/turma/` — page wrappers que renderizam a feature.
- `entities/usuarios/` — adicionado `UsuarioPublico` type + `buscarUsuarioPorId` API helper.
- `app/router.tsx` — duas novas rotas protegidas por `<ProtectedRoute allowedRoles={['STUDENT']}>`:
  - `/aluno/turmas` → lista
  - `/aluno/turmas/:id` → detalhe
- `widgets/header` — item de menu "Minhas Turmas" para o role STUDENT, com `BookOpen` icon e estado ativo em `location.pathname.startsWith("/aluno/turmas")`.

**UI:**

- Lista em grid responsivo (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`).
- Card de turma com `nome` + `ano.semestre`, ícone, ChevronRight, hover/focus tratados.
- Empty state com mensagem amigável: *"Você ainda não foi adicionado a nenhuma turma. Aguarde o convite do seu professor."*
- Detalhe com nome, semestre/ano, descrição da matéria, professor responsável (`{professor?.nome ?? 'Professor não disponível'}`) e botão de voltar.
- Estados de `carregando` / `sucesso` / `erro` / `nao-encontrada` no detalhe; `carregando` / `vazio` / `sucesso` / `erro` na lista.

**Detalhes técnicos:**

- O detalhe faz **2 requests**: `GET /turmas/:id` + `GET /usuarios/:professorId` (decisão DP-MT-01). Falha no lookup do professor cai em fallback "Professor não disponível" sem quebrar a tela.
- 404 do BFF/Quiz-Service vira estado `nao-encontrada` no front (detecção via `axios.isAxiosError(erro) && erro.response?.status === 404`).
- `<DetalheTurma key={id} />` no wrapper força remontagem ao trocar de turma — evita flash de dados antigos quando o usuário navega entre detalhes via histórico do browser.

### BFF (`2026-1-AnatoQuizUp-BFF`)

- Nenhuma mudança funcional: os proxies de `/turmas` e `/usuarios` já estavam mapeados.
- Testes de integração novos em `tests/integration/app.spec.ts` validando que requests de aluno chegam ao Quiz-Service / Usuario-Service com `X-User-Papel: ALUNO` injetado e que tentativas sem token caem em 401 sem acionar os downstreams.

### Quiz-Service (`2026-1-AnatoQuizUp-Quiz-Service`)

- `turma.routes.ts` refatorado: `middlewarePapeis(PROFESSOR, ADMINISTRADOR)` deixou de ser global no router e passou a ser aplicado **por rota** via helper `apenasGestao`. `GET /turmas` e `GET /turmas/:id` ficaram abertos a `ALUNO` / `PROFESSOR` / `ADMINISTRADOR`.
- `turma.service.ts` ganhou branching por papel:
  - **ALUNO** → `listarPorAluno(ctx.id, ...)`; query `?status=` rejeitada com **400** para evitar burlar o filtro de "apenas ATIVAs"; em `obterPorId`, falta de vínculo ou turma inativa retorna **404** (em vez de 403, para não vazar existência).
  - **PROFESSOR** → injeta `professorId: ctx.id` no filtro; em `obterPorId`, 403 se a turma não foi criada por ele.
  - **ADMINISTRADOR** → vê tudo sem filtro.
- `turma.repository.ts` ganhou `listarPorAluno` e `buscarVinculoAtivoAluno`.
- `turma.controller.ts` passa `req.usuario` como contexto para o service.
- `dto/turma.types.ts` ganhou `UsuarioContexto { id, papel }` e tornou `professorId` opcional em `FiltrosListagemTurma`.
- **Bônus de hardening:** removido `middlewareAutenticacao` duplicado do router (já aplicado globalmente em `roteadorApi.use`).

### Usuario-Service (`2026-1-AnatoQuizUp-Usuario-Service`)

- Novo endpoint `GET /api/v1/usuarios/:id` aberto a qualquer papel autenticado. Payload mínimo `{ id, nome, papel }` — **não vaza** email, senha, instituição, SIAPE, nem qualquer dado pessoal sensível.
- `usuarios.routes.ts` refatorado: `middlewarePapeis(PROFESSOR, ADMINISTRADOR)` deixou de ser global e virou helper `apenasGestao` aplicado por rota. `GET /usuarios/:id` fica sem o helper; `GET /usuarios?ids=` e `GET /usuarios/alunos` continuam restritos.
- `usuarios.service.ts` ganhou `buscarPorIdPublico` (404 se não existir ou estiver soft-deleted).
- `usuarios.repository.ts` ganhou `buscarPorIdPublico` com `select` mínimo (`id`, `nome`, `perfil`).
- `dto/usuario.types.ts` ganhou `UsuarioPublicoDto`, `converterPerfilParaPapel` (faz a ponte `PerfilUsuario.ADMIN` → `papel: 'ADMINISTRADOR'`) e `converterParaUsuarioPublico`.

### Doc (`2026-1-AnatoQuizUp-Doc`)

- Atualizações em `arquitetura/visao_geral.md`, `arquitetura/tecnologias.md`, `arquitetura/api/visao-geral.md`, `arquitetura/decisoes.md`, `decisoes/decisoes.md`, todas as visões em `arquitetura/visoes/`, e `contribuicao/setup-local.md` para refletir:
  - Quiz-Service ganhou domínio de turmas + vínculo `TurmaAluno`.
  - Novo endpoint `GET /api/v1/usuarios/:id` no Usuario-Service.
  - Nomenclatura padronizada: `Backend` → `Usuario-Service`.
- `mkdocs.yml` reorganizado.

---

## Decisões de Design

| ID | Decisão | Justificativa |
|---|---|---|
| **DP-MT-01** | Composição "Nome do Professor" — frontend faz 2 requests no detalhe | Simplicidade. `Turma.professorId` é ID externo (sem FK pro Auth DB). Evita criar endpoint composto no BFF. Lista não exibe nome do professor, então não há N+1 na listagem. |
| **DP-MT-02** | Listagem do aluno — apenas turmas ATIVAS | Status é estado administrativo do professor. Aluno não tem motivo de ver turmas encerradas. Query `?status=` é rejeitada com 400 para aluno (em vez de ignorada silenciosamente). |
| **DP-MT-03** | Detalhe não mostra lista de colegas | Fora do escopo desta US. Vira outra US futura (depende de batch lookup de usuários). |
| **DP-MT-04** | `GET /usuarios/:id` — payload mínimo `{ id, nome, papel }` | Evita vazamento de dados pessoais. Aluno consegue ver nome do professor, nada além. |
| **DP-MT-05** | `ProtectedRoute` mantém `allowedRoles={['STUDENT']}` (inglês) | Migrar `Role` PT-BR no front é débito conhecido (CLAUDE_CODE_CONTEXT §22) e fora do escopo desta PRD. A tradução `papel: ALUNO → role: STUDENT` é feita em `authService.mapPapelToRole`. |

---

## Critérios de Aceite (mapeados à US)

- [x] **Acesso Restrito** — rotas `/aluno/turmas` e `/aluno/turmas/:id` exigem JWT com papel ALUNO (validado no front via `ProtectedRoute` e no backend via Quiz-Service).
- [x] **Listagem de Turmas** — grid de cards com Nome + Semestre.
- [x] **Estado Vazio** — quando o aluno não está vinculado a nenhuma turma, exibe ilustração + mensagem amigável.
- [x] **Navegação e Detalhes** — clique no card navega para `/aluno/turmas/:id`.
- [x] **Informações Detalhadas** — exibe Nome, Semestre/Ano, Descrição da matéria, Nome do professor responsável (com fallback).
- [x] **Responsividade** — grid `1/2/3 colunas`, detalhe com `max-w-3xl` e padding responsivo.
- [x] **Cobertura ≥ 85%** em todos os 4 repos de código (gate de CI).
- [x] **Lint e build verdes** em todos os repos.
- [x] **Smoke test fim-a-fim** validado localmente.

---

## Como Testar Localmente

> Setup completo passo-a-passo em `2026-1-AnatoQuizUp-Doc/docs/contribuicao/setup-local.md`.

```powershell
# Terminal 1 - Usuario-Service
cd 2026-1-AnatoQuizUp-Usuario-Service
git checkout feature/minhas-turmas-aluno
docker compose up -d db
npm ci && npm run prisma:migrate && npm run prisma:seed
npm run dev   # :3333

# Terminal 2 - Quiz-Service
cd 2026-1-AnatoQuizUp-Quiz-Service
git checkout feature/minhas-turmas-aluno
docker compose up -d   # Postgres + MinIO
npm ci && npm run prisma:migrate
npm run dev   # :3334

# Terminal 3 - BFF
cd 2026-1-AnatoQuizUp-BFF
git checkout feature/minhas-turmas-aluno
npm ci && npm run dev   # :4000

# Terminal 4 - Web
cd 2026-1-AnatoQuizUp-Web
git checkout feature/minhas-turmas-aluno
npm ci && npm run dev   # :5173
```

**Fluxo de validação:**

1. **Login como professor** (`professor@anatoquizup.com` / `professor123` do seed) → menu lateral → **Turmas** → criar turma "Anatomia Sistêmica 2026.1".
2. **Em outra aba** → cadastre um aluno novo via `/cadastro` → faça login com ele.
3. **De volta como professor** → na turma → **Gerenciar alunos** → adicione o aluno cadastrado.
4. **Logue como aluno** → no menu lateral aparece **Minhas Turmas** → clique → deve listar a turma.
5. Clique no card → deve abrir o detalhe com nome do professor, descrição e semestre/ano.

**Casos a confirmar:**

- Aluno **sem turma** → empty state "Você ainda não foi adicionado a nenhuma turma."
- Aluno acessando `/aluno/turmas/<id-de-turma-de-outro>` direto pela URL → "Turma não encontrada" (404, não 403).
- Aluno acessando `/aluno/turmas/<id-invalido>` direto pela URL → "Turma não encontrada".
- Professor inativa a turma → aluno deixa de ver na listagem na próxima carga.
- Acessar `/aluno/turmas` como PROFESSOR → redireciona para `/home` (proteção do `ProtectedRoute`).

**Smoke tests via CLI:**

```powershell
$tokenAluno = "<jwt-de-aluno>"

# Quiz-Service rejeita aluno em rota de gestao
curl http://localhost:3334/api/v1/turmas -X POST -H "Authorization: Bearer $tokenAluno" -H "X-Internal-Token: <token>" -d "{}"
# Esperado: 403

# Quiz-Service permite aluno em rota de leitura
curl http://localhost:3334/api/v1/turmas -H "Authorization: Bearer $tokenAluno" -H "X-Internal-Token: <token>"
# Esperado: 200 com dados=[] ou lista vinculada

# Quiz-Service rejeita ?status= para aluno
curl "http://localhost:3334/api/v1/turmas?status=INATIVA" -H "Authorization: Bearer $tokenAluno" -H "X-Internal-Token: <token>"
# Esperado: 400 REQUISICAO_INVALIDA

# Usuario-Service devolve payload publico
curl http://localhost:3333/api/v1/usuarios/<professorId> -H "Authorization: Bearer $tokenAluno" -H "X-Internal-Token: <token>"
# Esperado: 200 com { id, nome, papel } — sem email
```

---

## Testes e Cobertura

| Repo | Suites | Testes | Cobertura |
|---|---|---|---|
| Usuario-Service | 40 | **265 / 265** passing | ≥ 85% |
| Quiz-Service | 21 | **152 / 152** passing | ≥ 85% |
| BFF | 9 | **63 / 63** passing | ≥ 85% |
| Web | 46 | **284 / 284** passing | ≥ 85% |

Lint clean e `tsc -b` clean em todos os repos.

---

## Riscos e Mitigações

| Risco | Mitigação |
|---|---|
| Aluno conseguir burlar filtro de status enviando `?status=INATIVA` | Service rejeita com **400** quando `ctx.papel === ALUNO && filtros.status !== undefined`. |
| Endpoint `/usuarios/:id` vazar dados sensíveis | Repository usa `select` explícito com `{ id, nome, perfil, excluidoEm }`. Service serializa para `{ id, nome, papel }` via `converterParaUsuarioPublico`. |
| Lookup do professor falhar (rede, deleção) e quebrar a tela de detalhe | Try/catch isolado em torno do `buscarUsuarioPorId`. Fallback "Professor não disponível" sem propagar erro. |
| Aluno acessando turma onde não está vinculado descobrir que ela existe | Retorno **404** em vez de 403 (DP-MT-02 do PRD original). Mesma resposta de "turma não existe". |
| Composição "nome do professor" via 2 requests criar latência | Aceitável para MVP; lookup é rápido em rede privada. Se virar gargalo, criar endpoint composto no BFF em PR de melhoria. |

---

## Fora de Escopo (out of scope)

- Lista de colegas de turma na visualização do aluno (vira US própria — requer batch lookup de usuários).
- Aluno se desvincular sozinho da turma (apenas professor pode desvincular hoje).
- Aluno entrar em turma por código de convite (vinculação é direta pelo professor).
- Visualização de quizzes/histórico da turma pelo aluno (integra com módulo de quiz; outra US).
- Refactor PT-BR completo de `entities/user` no Web (`Role: STUDENT|PROFESSOR|ADMIN` → `Papel: ALUNO|PROFESSOR|ADMINISTRADOR`) — débito conhecido.
- Migration de renome do enum Prisma `PerfilUsuario.ADMIN` → `ADMINISTRADOR` no Usuario-Service.

## Checklist

- [x] Código segue Conventional Commits (todos os commits) e Git Flow (`feature/minhas-turmas-aluno` em cada repo).
- [x] PR vinculado à User Story de "Minhas Turmas (Aluno)".
- [x] Testes adicionados/atualizados (cobertura ≥ 85% em todos os 4 repos).
- [x] Lint, build e `tsc` verdes localmente em todos os repos.
- [x] Code review interno aplicado e ajustes do Copilot avaliados (4 ajustes implementados, 2 anotados como débito, 2 rejeitados por contexto).
- [x] Nenhum dado sensível exposto pelo novo endpoint `/usuarios/:id`.
- [x] Smoke test fim-a-fim validado localmente.
- [x] Documentação atualizada no repo Doc.
- [ ] PRs cross-repo aprovados na ordem de merge sugerida (Usuario-Service → Quiz-Service → BFF → Web → Doc).

---

## Observações

- O documento `CLAUDE_CODE_CONTEXT.md` na raiz do Web permanece local (não commitado), conforme combinado.
- Foram identificados débitos pré-existentes durante a review que **não foram tratados** nesta entrega e podem virar issues separadas:
  - Consolidar 3 cópias de `converterPerfilParaPapel` no Usuario-Service em um util compartilhado.
  - Deduplicar `normalizarTurma` entre `DetalheTurma.tsx` e `entities/turmas/api/turmaApi.ts` (requer expor `professorId` no entity layer).
  - Remover `prisma db seed` do `CMD` do Dockerfile do Quiz-Service em produção (seed tem IDs hardcoded de teste).
  - Alinhar Node 24 no CI do Web (hoje roda Node 20).
- Foi corrigido neste PR um problema de deploy descoberto na rodada: o `npx prisma db seed` em produção falhava silenciosamente porque (a) não havia bloco `"prisma": { "seed": "..." }` no `package.json` do Usuario-Service e (b) `tsx` está em `devDependencies` e não existe na imagem runtime. O fix aponta o seed para `node dist/prisma/seed.js` (gerado pelo build). Isso permite que admin/professor placeholders do seed sejam criados no boot em produção.

---