### PR TITLE
Feat/moedas atp

### DIFF
--- a/src/app/layouts/AuthenticatedLayout.test.tsx
+++ b/src/app/layouts/AuthenticatedLayout.test.tsx
@@ -2,6 +2,10 @@ jest.mock('../../widgets/header', () => ({
   Header: () => <header>App header</header>,
 }));
 
+jest.mock('../../features/student-coins', () => ({
+  StudentCoinsBootstrap: () => null,
+}));
+
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { AuthenticatedLayout } from './AuthenticatedLayout';

--- a/src/app/layouts/AuthenticatedLayout.tsx
+++ b/src/app/layouts/AuthenticatedLayout.tsx
@@ -1,8 +1,10 @@
 import { Outlet } from 'react-router-dom';
 import { Header } from '../../widgets/header';
+import { StudentCoinsBootstrap } from '../../features/student-coins';
 
 export const AuthenticatedLayout = () => (
   <div className="min-h-screen flex flex-col md:flex-row bg-white">
+    <StudentCoinsBootstrap />
     <Header />
     <main className="flex-1 min-w-0">
       <Outlet />

--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -31,3 +31,20 @@
     transform: scale(1);
   }
 }
+
+@keyframes coins-reward-rise {
+  0% {
+    opacity: 0;
+    transform: translateY(10px) scale(0.94);
+  }
+
+  45% {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.04);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/src/features/random-quiz/randomQuizService.test.ts
+++ b/src/features/random-quiz/randomQuizService.test.ts
@@ -1,4 +1,9 @@
-import { buscarQuestoesQuiz, responderQuestaoQuiz, buscarQuantidadeDeQuestoesPorTema } from './randomQuizService';
+import {
+  buscarQuestoesQuiz,
+  responderQuestaoQuiz,
+  buscarQuantidadeDeQuestoesPorTema,
+  buscarSaldoMoedas,
+} from './randomQuizService';
 import { httpClient } from '../../shared/api/httpClient';
 import type { ApiQuestionDifficulty, ApiQuestionType, QuestionAlternativeKey } from '../manage-questions';
 
@@ -45,7 +50,14 @@ describe('randomQuizService', () => {
 
   describe('responderQuestaoQuiz', () => {
     it('deve responder questão com sucesso', async () => {
-      const mockFeedback = { correcao: true, saibaMais: 'teste' };
+      const mockFeedback = {
+        correcao: true,
+        saibaMais: 'teste',
+        respostaCorreta: 'A',
+        moedasConcedidas: 10,
+        saldoMoedas: 10,
+        moedasJaConcedidas: false,
+      };
       (httpClient.post as jest.Mock).mockResolvedValue({ data: mockFeedback });
 
       const payload = {
@@ -70,6 +82,24 @@ describe('randomQuizService', () => {
       (httpClient.post as jest.Mock).mockRejectedValue(new Error('Server Error'));
 
       await expect(responderQuestaoQuiz(payload)).rejects.toThrow('Erro simulado pelo mock');
+    });
+  });
+
+  describe('buscarSaldoMoedas', () => {
+    it('deve buscar saldo de ATP com sucesso', async () => {
+      const mockSaldo = { saldoMoedas: 75 };
+      (httpClient.get as jest.Mock).mockResolvedValue({ data: mockSaldo });
+
+      const result = await buscarSaldoMoedas();
+
+      expect(httpClient.get).toHaveBeenCalledWith('/quiz/moedas');
+      expect(result).toEqual(mockSaldo);
+    });
+
+    it('deve cair no catch e disparar erro ao falhar na busca de saldo', async () => {
+      (httpClient.get as jest.Mock).mockRejectedValue(new Error('API Down'));
+
+      await expect(buscarSaldoMoedas()).rejects.toThrow('Erro simulado pelo mock');
     });
   });
 

--- a/src/features/random-quiz/randomQuizService.ts
+++ b/src/features/random-quiz/randomQuizService.ts
@@ -1,7 +1,7 @@
 import { httpClient } from '../../shared/api/httpClient';
 import type { QuestionListParams } from '../manage-questions';
 import { extractErrorMessage } from '../manage-questions/model/questionService';
-import type { ListQuizQuestionResponse, QuantidadeQuestoesTema, QuantidadeQuestoesTemaResponse, QuestaoQuizAnwser, QuestaoQuizFeedback } from './types';
+import type { ListQuizQuestionResponse, QuantidadeQuestoesTema, QuantidadeQuestoesTemaResponse, QuestaoQuizAnwser, QuestaoQuizFeedback, SaldoMoedasResponse } from './types';
 
 const QUIZ_ENDPOINT = '/quiz';
 
@@ -29,6 +29,17 @@ export const responderQuestaoQuiz = async (
             params 
         );
         return data
+    } catch (error) {
+        throw new Error(extractErrorMessage(error));
+    }
+}
+
+export const buscarSaldoMoedas = async (): Promise<SaldoMoedasResponse> => {
+    try {
+        const { data } = await httpClient.get<SaldoMoedasResponse>(
+            `${QUIZ_ENDPOINT}/moedas`
+        );
+        return data;
     } catch (error) {
         throw new Error(extractErrorMessage(error));
     }

--- a/src/features/random-quiz/types.ts
+++ b/src/features/random-quiz/types.ts
@@ -25,6 +25,14 @@ export type QuestaoQuizAnwser = {
 export type QuestaoQuizFeedback = {
   correcao: boolean;
   saibaMais: string | null;
+  respostaCorreta: QuestionAlternativeKey;
+  moedasConcedidas: number;
+  saldoMoedas: number;
+  moedasJaConcedidas: boolean;
+}
+
+export type SaldoMoedasResponse = {
+  saldoMoedas: number;
 }
 
 export type Dificuldade = "FACIL" | "MEDIA" | "DIFICIL"

--- a/src/features/student-coins/index.ts
+++ b/src/features/student-coins/index.ts
@@ -1,0 +1,2 @@
+export { useStudentCoinsStore } from './model/useStudentCoinsStore';
+export { StudentCoinsBootstrap } from './ui/StudentCoinsBootstrap';

--- a/src/features/student-coins/model/useStudentCoinsStore.test.tsx
+++ b/src/features/student-coins/model/useStudentCoinsStore.test.tsx
@@ -1,0 +1,52 @@
+import { act } from '@testing-library/react';
+import { useStudentCoinsStore } from './useStudentCoinsStore';
+
+describe('useStudentCoinsStore', () => {
+  beforeEach(() => {
+    useStudentCoinsStore.getState().reset();
+  });
+
+  it('updates saldoMoedas', () => {
+    act(() => {
+      useStudentCoinsStore.getState().setSaldoMoedas(150);
+    });
+
+    expect(useStudentCoinsStore.getState().saldoMoedas).toBe(150);
+  });
+
+  it('updates loading state', () => {
+    act(() => {
+      useStudentCoinsStore.getState().setLoading(true);
+    });
+
+    expect(useStudentCoinsStore.getState().isLoading).toBe(true);
+  });
+
+  it('updates error state', () => {
+    act(() => {
+      useStudentCoinsStore.getState().setError('erro');
+    });
+
+    expect(useStudentCoinsStore.getState().error).toBe('erro');
+  });
+
+  it('resets state', () => {
+    act(() => {
+      const state = useStudentCoinsStore.getState();
+
+      state.setSaldoMoedas(100);
+      state.setLoading(true);
+      state.setError('falha');
+    });
+
+    act(() => {
+      useStudentCoinsStore.getState().reset();
+    });
+
+    expect(useStudentCoinsStore.getState()).toMatchObject({
+      saldoMoedas: 0,
+      isLoading: false,
+      error: null,
+    });
+  });
+});

--- a/src/features/student-coins/model/useStudentCoinsStore.ts
+++ b/src/features/student-coins/model/useStudentCoinsStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+type StudentCoinsState = {
+  saldoMoedas: number;
+  isLoading: boolean;
+  error: string | null;
+  setSaldoMoedas: (saldoMoedas: number) => void;
+  setLoading: (isLoading: boolean) => void;
+  setError: (error: string | null) => void;
+  reset: () => void;
+};
+
+export const useStudentCoinsStore = create<StudentCoinsState>((set) => ({
+  saldoMoedas: 0,
+  isLoading: false,
+  error: null,
+  setSaldoMoedas: (saldoMoedas) => set({ saldoMoedas }),
+  setLoading: (isLoading) => set({ isLoading }),
+  setError: (error) => set({ error }),
+  reset: () => set({ saldoMoedas: 0, isLoading: false, error: null }),
+}));

--- a/src/features/student-coins/ui/StudentCoinsBootstrap.test.tsx
+++ b/src/features/student-coins/ui/StudentCoinsBootstrap.test.tsx
@@ -1,0 +1,91 @@
+import { render, waitFor } from '@testing-library/react';
+
+import { StudentCoinsBootstrap } from './StudentCoinsBootstrap';
+
+import { useAuth } from '../../../app/providers/AuthProvider';
+import { buscarSaldoMoedas } from '../../random-quiz/randomQuizService';
+import { useStudentCoinsStore } from '../model/useStudentCoinsStore';
+
+jest.mock('../../../app/providers/AuthProvider', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('../../random-quiz/randomQuizService', () => ({
+  buscarSaldoMoedas: jest.fn(),
+}));
+
+jest.mock('../model/useStudentCoinsStore', () => ({
+  useStudentCoinsStore: jest.fn(),
+}));
+
+describe('StudentCoinsBootstrap', () => {
+  const mockSetSaldoMoedas = jest.fn();
+  const mockSetLoading = jest.fn();
+  const mockSetError = jest.fn();
+  const mockReset = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useStudentCoinsStore as jest.Mock).mockImplementation((selector) =>
+      selector({
+        saldoMoedas: 0,
+        isLoading: false,
+        error: null,
+        setSaldoMoedas: mockSetSaldoMoedas,
+        setLoading: mockSetLoading,
+        setError: mockSetError,
+        reset: mockReset,
+      }),
+    );
+  });
+
+  it('calls reset for non-student users', () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { role: 'ADMIN' },
+    });
+
+    render(<StudentCoinsBootstrap />);
+
+    expect(mockReset).toHaveBeenCalled();
+  });
+
+  it('loads and stores saldo for students', async () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { role: 'STUDENT' },
+    });
+
+    (buscarSaldoMoedas as jest.Mock).mockResolvedValue({
+      saldoMoedas: 250,
+    });
+
+    render(<StudentCoinsBootstrap />);
+
+    await waitFor(() => {
+      expect(mockSetSaldoMoedas).toHaveBeenCalledWith(250);
+    });
+
+    expect(mockSetLoading).toHaveBeenCalledWith(true);
+    expect(mockSetLoading).toHaveBeenCalledWith(false);
+
+    expect(mockSetError).toHaveBeenCalledWith(null);
+  });
+
+  it('stores error when request fails', async () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { role: 'STUDENT' },
+    });
+
+    (buscarSaldoMoedas as jest.Mock).mockRejectedValue(
+      new Error('Erro de API'),
+    );
+
+    render(<StudentCoinsBootstrap />);
+
+    await waitFor(() => {
+      expect(mockSetError).toHaveBeenCalledWith('Erro de API');
+    });
+
+    expect(mockSetLoading).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/features/student-coins/ui/StudentCoinsBootstrap.tsx
+++ b/src/features/student-coins/ui/StudentCoinsBootstrap.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+
+import { useAuth } from '../../../app/providers/AuthProvider';
+import { buscarSaldoMoedas } from '../../random-quiz/randomQuizService';
+import { useStudentCoinsStore } from '../model/useStudentCoinsStore';
+
+export const StudentCoinsBootstrap = () => {
+  const { user } = useAuth();
+  const setSaldoMoedas = useStudentCoinsStore((state) => state.setSaldoMoedas);
+  const setLoading = useStudentCoinsStore((state) => state.setLoading);
+  const setError = useStudentCoinsStore((state) => state.setError);
+  const reset = useStudentCoinsStore((state) => state.reset);
+
+  useEffect(() => {
+    if (user?.role !== 'STUDENT') {
+      reset();
+      return;
+    }
+
+    let isMounted = true;
+
+    const carregarSaldo = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const { saldoMoedas } = await buscarSaldoMoedas();
+
+        if (isMounted) {
+          setSaldoMoedas(saldoMoedas);
+        }
+      } catch (error) {
+        if (isMounted) {
+          setError(error instanceof Error ? error.message : 'Erro ao buscar saldo de moedas.');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void carregarSaldo();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [reset, setError, setLoading, setSaldoMoedas, user?.role]);
+
+  return null;
+};

--- a/src/features/student-coins/ui/StudentCoinsBootstrap.tsx
+++ b/src/features/student-coins/ui/StudentCoinsBootstrap.tsx
@@ -31,7 +31,7 @@ export const StudentCoinsBootstrap = () => {
         }
       } catch (error) {
         if (isMounted) {
-          setError(error instanceof Error ? error.message : 'Erro ao buscar saldo de moedas.');
+          setError(error instanceof Error ? error.message : 'Erro ao buscar saldo de ATP.');
         }
       } finally {
         if (isMounted) {

--- a/src/pages/quizAluno/ui/ResponderQuizPage.test.tsx
+++ b/src/pages/quizAluno/ui/ResponderQuizPage.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/re
 import { MemoryRouter } from 'react-router-dom';
 import { ResponderQuizPage } from './ResponderQuizPage';
 import * as randomQuizService from '../../../features/random-quiz/randomQuizService';
+import { useStudentCoinsStore } from '../../../features/student-coins/model/useStudentCoinsStore';
 
 jest.mock('../../../features/random-quiz/randomQuizService');
 
@@ -15,9 +16,29 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+const feedback = (
+  overrides: Partial<{
+    correcao: boolean;
+    saibaMais: string | null;
+    respostaCorreta: 'A' | 'B' | 'C' | 'D' | 'E';
+    moedasConcedidas: number;
+    saldoMoedas: number;
+    moedasJaConcedidas: boolean;
+  }> = {},
+) => ({
+  correcao: true,
+  saibaMais: 'Certo!',
+  respostaCorreta: 'A' as const,
+  moedasConcedidas: 10,
+  saldoMoedas: 10,
+  moedasJaConcedidas: false,
+  ...overrides,
+});
+
 describe('ResponderQuizPage - Treino Infinito', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useStudentCoinsStore.getState().reset();
     jest.useFakeTimers();
   });
 
@@ -56,7 +77,13 @@ describe('ResponderQuizPage - Treino Infinito', () => {
     await waitFor(() => expect(screen.getByText('Q1?')).toBeInTheDocument());
 
     fireEvent.click(screen.getByText('Alt B'));
-    (randomQuizService.responderQuestaoQuiz as jest.Mock).mockResolvedValueOnce({ correcao: false, saibaMais: 'Errado!' });
+    (randomQuizService.responderQuestaoQuiz as jest.Mock).mockResolvedValueOnce(feedback({
+      correcao: false,
+      saibaMais: 'Errado!',
+      respostaCorreta: 'A',
+      moedasConcedidas: 0,
+      saldoMoedas: 0,
+    }));
     fireEvent.click(screen.getByRole('button', { name: /Confirmar/i }));
     
     await waitFor(() => expect(screen.getByRole('button', { name: /Próxima/i })).toBeInTheDocument());
@@ -68,11 +95,61 @@ describe('ResponderQuizPage - Treino Infinito', () => {
     expect(screen.getByText('2')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('Alt C'));
-    (randomQuizService.responderQuestaoQuiz as jest.Mock).mockResolvedValueOnce({ correcao: true, saibaMais: 'Certo!' });
+    (randomQuizService.responderQuestaoQuiz as jest.Mock).mockResolvedValueOnce(feedback({
+      respostaCorreta: 'C',
+      moedasConcedidas: 25,
+      saldoMoedas: 25,
+    }));
     fireEvent.click(screen.getByRole('button', { name: /Confirmar/i }));
     
     await waitFor(() => expect(screen.getByRole('button', { name: /Próxima/i })).toBeInTheDocument());
     expect(screen.getByText('50%')).toBeInTheDocument();
+  });
+
+  it('deve exibir ganho de ATP e atualizar saldo global ao acertar', async () => {
+    (randomQuizService.buscarQuestoesQuiz as jest.Mock).mockResolvedValue({
+      dados: [{ id: '1', enunciado: 'Q ATP?', tipo: 'MULTIPLA_ESCOLHA', alternativas: { A: 'Alt A' }, dificuldade: 'FACIL' }],
+      metadados: { total: 1 },
+    });
+    (randomQuizService.responderQuestaoQuiz as jest.Mock).mockResolvedValueOnce(feedback({
+      respostaCorreta: 'A',
+      moedasConcedidas: 10,
+      saldoMoedas: 40,
+    }));
+
+    render(<MemoryRouter><ResponderQuizPage /></MemoryRouter>);
+
+    await waitFor(() => expect(screen.getByText('Q ATP?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Alt A'));
+    fireEvent.click(screen.getByRole('button', { name: /Confirmar/i }));
+
+    await waitFor(() => expect(screen.getByText('+10 ATP')).toBeInTheDocument());
+    expect(useStudentCoinsStore.getState().saldoMoedas).toBe(40);
+  });
+
+  it('nao deve exibir ganho de ATP quando acerto nao concede recompensa', async () => {
+    (randomQuizService.buscarQuestoesQuiz as jest.Mock).mockResolvedValue({
+      dados: [{ id: '1', enunciado: 'Q sem ATP?', tipo: 'MULTIPLA_ESCOLHA', alternativas: { A: 'Alt A' }, dificuldade: 'FACIL' }],
+      metadados: { total: 1 },
+    });
+    (randomQuizService.responderQuestaoQuiz as jest.Mock).mockResolvedValueOnce(feedback({
+      respostaCorreta: 'A',
+      moedasConcedidas: 0,
+      saldoMoedas: 40,
+      moedasJaConcedidas: true,
+    }));
+
+    render(<MemoryRouter><ResponderQuizPage /></MemoryRouter>);
+
+    await waitFor(() => expect(screen.getByText('Q sem ATP?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Alt A'));
+    fireEvent.click(screen.getByRole('button', { name: /Confirmar/i }));
+
+    await waitFor(() => expect(screen.getByText('Resposta Correta!')).toBeInTheDocument());
+    expect(screen.queryByText(/\+0 ATP/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\+\d+ ATP/i)).not.toBeInTheDocument();
   });
 
   it('deve disparar erro inicial no useEffect', async () => {
@@ -121,7 +198,7 @@ const botaoAlternativa = screen.getAllByRole('button').find(btn => btn.textConte
         fireEvent.click(botaoAlternativa);
     }
 
-    (randomQuizService.responderQuestaoQuiz as jest.Mock).mockResolvedValueOnce({ correcao: true });
+    (randomQuizService.responderQuestaoQuiz as jest.Mock).mockResolvedValueOnce(feedback({ respostaCorreta: 'A' }));
     fireEvent.click(screen.getByRole('button', { name: /Confirmar/i }));
     await waitFor(() => expect(screen.getByRole('button', { name: /Próxima/i })).toBeInTheDocument());
 

--- a/src/pages/quizAluno/ui/ResponderQuizPage.tsx
+++ b/src/pages/quizAluno/ui/ResponderQuizPage.tsx
@@ -5,6 +5,7 @@ import { Clock, ArrowLeft, CheckCircle2, XCircle, PauseCircle, PlayCircle, Chevr
 import { buscarQuestoesQuiz, responderQuestaoQuiz } from '../../../features/random-quiz/randomQuizService';
 import type { QuizQuestion, QuestaoQuizFeedback } from '../../../features/random-quiz/types';
 import type { ApiQuestionDifficulty } from '../../../features/manage-questions';
+import { useStudentCoinsStore } from '../../../features/student-coins';
 
 export const ResponderQuizPage = () => {
   const navigate = useNavigate();
@@ -12,6 +13,7 @@ export const ResponderQuizPage = () => {
   const [searchParams] = useSearchParams();
   const temaQuery = searchParams.get('tema') || '';
   const dificuldadeQuery = searchParams.get('dificuldade') || '';
+  const setSaldoMoedas = useStudentCoinsStore((state) => state.setSaldoMoedas);
 
   const [questoes, setQuestoes] = useState<QuizQuestion[]>([]);
   const [feedback, setFeedback] = useState<QuestaoQuizFeedback & { respostaCorreta?: string } | null>(null);
@@ -140,6 +142,7 @@ export const ResponderQuizPage = () => {
       });
 
       setFeedback(response);
+      setSaldoMoedas(response.saldoMoedas);
       setJaRespondeu(true);
       setIsPaused(true);
 

--- a/src/pages/quizAluno/ui/ResponderQuizPage.tsx
+++ b/src/pages/quizAluno/ui/ResponderQuizPage.tsx
@@ -5,7 +5,7 @@ import { Clock, ArrowLeft, CheckCircle2, XCircle, PauseCircle, PlayCircle, Chevr
 import { buscarQuestoesQuiz, responderQuestaoQuiz } from '../../../features/random-quiz/randomQuizService';
 import type { QuizQuestion, QuestaoQuizFeedback } from '../../../features/random-quiz/types';
 import type { ApiQuestionDifficulty } from '../../../features/manage-questions';
-import { useStudentCoinsStore } from '../../../features/student-coins';
+import { useStudentCoinsStore } from '../../../features/student-coins/model/useStudentCoinsStore';
 
 export const ResponderQuizPage = () => {
   const navigate = useNavigate();

--- a/src/pages/quizAluno/ui/ResponderQuizPage.tsx
+++ b/src/pages/quizAluno/ui/ResponderQuizPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Clock, ArrowLeft, CheckCircle2, XCircle, PauseCircle, PlayCircle, ChevronRight, Check, Loader2, Flag } from 'lucide-react';
+import { Clock, ArrowLeft, CheckCircle2, XCircle, PauseCircle, PlayCircle, ChevronRight, Check, Loader2, Flag, Coins } from 'lucide-react';
 
 import { buscarQuestoesQuiz, responderQuestaoQuiz } from '../../../features/random-quiz/randomQuizService';
 import type { QuizQuestion, QuestaoQuizFeedback } from '../../../features/random-quiz/types';
@@ -122,6 +122,7 @@ export const ResponderQuizPage = () => {
   }
 
   const acertou = feedback?.correcao ?? false;
+  const deveMostrarGanhoMoedas = acertou && (feedback?.moedasConcedidas ?? 0) > 0;
 
   const taxaAcerto = questoesRespondidas === 0 ? 0 : (acertos / questoesRespondidas) * 100;
 
@@ -383,10 +384,22 @@ export const ResponderQuizPage = () => {
         )}
 
         {jaRespondeu && feedback?.saibaMais && (
-          <div className={`rounded-xl p-6 border animate-fade-in ${acertou ? 'bg-[#E6FCFA] border-[#14D5C2]' : 'bg-rose-50 border-rose-200'}`}>
-            <h3 className={`text-sm font-black mb-2 uppercase tracking-wide ${acertou ? 'text-[#0E9384]' : 'text-rose-700'}`}>
-              {acertou ? 'Resposta Correta!' : 'Resposta Incorreta!'}
-            </h3>
+          <div className={`rounded-xl p-6 border animate-fade-in relative overflow-hidden ${acertou ? 'bg-[#E6FCFA] border-[#14D5C2]' : 'bg-rose-50 border-rose-200'}`}>
+            <div className="flex items-start justify-between gap-4 mb-2">
+              <h3 className={`text-sm font-black uppercase tracking-wide ${acertou ? 'text-[#0E9384]' : 'text-rose-700'}`}>
+                {acertou ? 'Resposta Correta!' : 'Resposta Incorreta!'}
+              </h3>
+
+              {deveMostrarGanhoMoedas && (
+                <div
+                  className="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-[#F59E0B] px-3 py-1.5 text-xs font-black text-[#0A1128] shadow-lg shadow-[#F59E0B]/20"
+                  style={{ animation: 'coins-reward-rise 900ms ease-out both' }}
+                >
+                  <Coins className="w-4 h-4" />
+                  +{feedback.moedasConcedidas} moedas
+                </div>
+              )}
+            </div>
 
             <p className="text-sm font-medium leading-relaxed text-[#0A1128]/80">
               {feedback.saibaMais}

--- a/src/pages/quizAluno/ui/ResponderQuizPage.tsx
+++ b/src/pages/quizAluno/ui/ResponderQuizPage.tsx
@@ -396,7 +396,7 @@ export const ResponderQuizPage = () => {
                   style={{ animation: 'coins-reward-rise 900ms ease-out both' }}
                 >
                   <Coins className="w-4 h-4" />
-                  +{feedback.moedasConcedidas} moedas
+                  +{feedback.moedasConcedidas} ATP
                 </div>
               )}
             </div>

--- a/src/widgets/header/ui/Header.test.tsx
+++ b/src/widgets/header/ui/Header.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { useAuth } from '../../../app/providers/AuthProvider';
 import type { AuthState, Role, User } from '../../../entities/user/model/types';
+import { useStudentCoinsStore } from '../../../features/student-coins/model/useStudentCoinsStore';
 import { Header } from './Header';
 
 const useAuthMock = useAuth as jest.Mock;
@@ -43,6 +44,10 @@ const renderHeader = (auth: Partial<AuthState>, route = '/home') => {
 };
 
 describe('Header', () => {
+  beforeEach(() => {
+    useStudentCoinsStore.getState().reset();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -65,6 +70,24 @@ describe('Header', () => {
     await waitFor(() => {
       expect(screen.getByTestId('location')).toHaveTextContent('/login');
     });
+  });
+
+  it('renders ATP balance for students', () => {
+    useStudentCoinsStore.getState().setSaldoMoedas(125);
+
+    renderHeader({ user: makeUser('STUDENT'), isAuthenticated: true });
+
+    expect(screen.getByText('ATP')).toBeInTheDocument();
+    expect(screen.getAllByText('125')).toHaveLength(2);
+  });
+
+  it('does not render ATP balance for professors', () => {
+    useStudentCoinsStore.getState().setSaldoMoedas(125);
+
+    renderHeader({ user: makeUser('PROFESSOR'), isAuthenticated: true });
+
+    expect(screen.queryByText('ATP')).not.toBeInTheDocument();
+    expect(screen.queryByText('125')).not.toBeInTheDocument();
   });
 
   it('toggles professor student-view navigation state', async () => {

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -184,7 +184,7 @@ export const Header = () => {
                 <Coins size={18} />
               </div>
               <span className="text-xs font-black uppercase tracking-widest text-[#fffffe]/70">
-                Moedas
+                ATP
               </span>
             </div>
             <span className="text-lg font-black text-[#FDE68A] tabular-nums">

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -5,7 +5,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../../../app/providers/AuthProvider";
 import logo from "../../../shared/assets/image/logo.png";
 import type { Role } from "../../../entities/user/model/types";
-import { useStudentCoinsStore } from "../../../features/student-coins";
+import { useStudentCoinsStore } from "../../../features/student-coins/model/useStudentCoinsStore";
 
 type NavItem = {
   key: string;

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import type { LucideIcon } from "lucide-react";
-import { Eye, Home, LogOut, Menu, Users, X, Newspaper, BookOpen } from "lucide-react";
+import { BookOpen, Coins, Eye, Home, LogOut, Menu, Newspaper, Users, X } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../../../app/providers/AuthProvider";
 import logo from "../../../shared/assets/image/logo.png";
 import type { Role } from "../../../entities/user/model/types";
+import { useStudentCoinsStore } from "../../../features/student-coins";
 
 type NavItem = {
   key: string;
@@ -16,6 +17,7 @@ type NavItem = {
 
 export const Header = () => {
   const { user, logout } = useAuth();
+  const saldoMoedas = useStudentCoinsStore((state) => state.saldoMoedas);
   const navigate = useNavigate();
   const location = useLocation();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -139,6 +141,7 @@ export const Header = () => {
 
   const navItems = buildNavItems(user.role);
   const initial = user.name?.charAt(0).toUpperCase() || "U";
+  const shouldShowCoins = user.role === "STUDENT";
 
   const handleSelect = (item: NavItem) => {
     item.onSelect();
@@ -174,6 +177,22 @@ export const Header = () => {
       </nav>
 
       <div className="border-t border-[#00214d] p-4 flex flex-col gap-3">
+        {shouldShowCoins && (
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-[#F59E0B]/30 bg-[#F59E0B]/10 px-4 py-3 text-[#fffffe]">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="w-9 h-9 rounded-full bg-[#F59E0B] text-[#0A1128] flex items-center justify-center shrink-0">
+                <Coins size={18} />
+              </div>
+              <span className="text-xs font-black uppercase tracking-widest text-[#fffffe]/70">
+                Moedas
+              </span>
+            </div>
+            <span className="text-lg font-black text-[#FDE68A] tabular-nums">
+              {saldoMoedas}
+            </span>
+          </div>
+        )}
+
         <div className="flex items-center gap-3 px-2">
           <div className="w-10 h-10 bg-[#00214d] border border-[#71edc8] rounded-full flex items-center justify-center text-[#71edc8] text-sm font-black shrink-0">
             {initial}
@@ -205,14 +224,24 @@ export const Header = () => {
         <button onClick={() => navigate("/home")} className="flex items-center">
           <img src={logo} alt="AnatoQuizUp" className="h-10" />
         </button>
-        <button
-          onClick={() => setIsDrawerOpen(true)}
-          className="p-2 text-[#fffffe] hover:text-[#71edc8] transition-colors"
-          aria-label="Abrir menu"
-          aria-expanded={isDrawerOpen}
-        >
-          <Menu size={24} />
-        </button>
+
+        <div className="flex items-center gap-2">
+          {shouldShowCoins && (
+            <div className="h-9 min-w-20 px-3 rounded-full bg-[#F59E0B]/15 border border-[#F59E0B]/30 text-[#FDE68A] flex items-center justify-center gap-1.5">
+              <Coins size={16} />
+              <span className="text-sm font-black tabular-nums">{saldoMoedas}</span>
+            </div>
+          )}
+
+          <button
+            onClick={() => setIsDrawerOpen(true)}
+            className="p-2 text-[#fffffe] hover:text-[#71edc8] transition-colors"
+            aria-label="Abrir menu"
+            aria-expanded={isDrawerOpen}
+          >
+            <Menu size={24} />
+          </button>
+        </div>
       </div>
 
       <aside className="hidden md:flex w-64 bg-[#0A1128] text-[#fffffe] flex-col sticky top-0 h-screen shrink-0">


### PR DESCRIPTION
## Descrição

Integra a mecânica de **ATP** no front-end do aluno.

O Web agora consome o saldo de ATP do aluno, exibe esse saldo no header e atualiza o valor imediatamente após o aluno responder uma questão. Quando a resposta correta gera recompensa, o quiz exibe um feedback visual como:

```text
+25 ATP
```

A interface apenas reflete os dados calculados pelo Quiz-Service. A regra de pontuação e a proteção anti-farm permanecem no back-end.

## Rastreabilidade

Issue(s) Relacionada(s):

Closes: #77

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (corção de erro)
- [x] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Evidências (se aplicável)

- Saldo de ATP exibido no header do aluno.
<img width="370" height="908" alt="image" src="https://github.com/user-attachments/assets/c6ab28c0-958d-40ec-b0e0-97e2d9d6098b" />

- Feedback visual de ganho de ATP exibido após acerto.
<img width="1045" height="824" alt="image" src="https://github.com/user-attachments/assets/9dd8e425-2e5a-42cf-ae82-fdf830178c71" />

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

O saldo é carregado quando o usuário autenticado é aluno. Para professor/admin, a store é resetada e o saldo de ATP não é exibido.