### PR TITLE
Feat/dashboard turma

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -14,6 +14,7 @@ import { CreateQuestionPage } from "../pages/professor/criar-questao";
 import { TurmasPage } from "../pages/turma/ui/TurmaPage";
 import { MinhasTurmasAlunoPage } from "../pages/aluno/minhas-turmas";
 import { TurmaDetalheAlunoPage } from "../pages/aluno/turma";
+import { TurmaDetalhesPage } from "../pages/TurmaDetalhes";
 
 import { ListaPage } from "../pages/lista-professor/ui/ListaPage";
 import { EscolhaQuizPage, ResponderQuizPage } from "../pages/quizAluno";
@@ -148,6 +149,15 @@ export const AppRouter = () => {
           element={
             <ProtectedRoute allowedRoles={['PROFESSOR', 'ADMIN']}>
               <TurmasPage />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/turmas/:id"
+          element={
+            <ProtectedRoute allowedRoles={['PROFESSOR', 'ADMIN']}>
+              <TurmaDetalhesPage />
             </ProtectedRoute>
           }
         />

--- a/src/entities/dashboardTurma/api/dashboardTurmaApi.test.ts
+++ b/src/entities/dashboardTurma/api/dashboardTurmaApi.test.ts
@@ -1,4 +1,4 @@
-import { buscarDashboardMacro } from './dashboardTurmaApi';
+import { buscarDashboardMacro, buscarDesempenhoIndividual } from './dashboardTurmaApi';
 import { httpClient } from '../../../shared/api/httpClient';
 
 jest.mock('../../../shared/api/httpClient', () => ({
@@ -8,14 +8,51 @@ jest.mock('../../../shared/api/httpClient', () => ({
 }));
 
 describe('dashboardTurmaApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('deve chamar a API e retornar os dados do macro dashboard', async () => {
     const mockData = { totalAlunos: 10, totalQuestoesRespondidas: 5, taxaMediaAcertos: 50, desempenhoPorTema: [] };
-    
+
     (httpClient.get as jest.Mock).mockResolvedValue({ data: mockData });
 
     const result = await buscarDashboardMacro('turma-123');
 
     expect(httpClient.get).toHaveBeenCalledWith('/turmasDashboard/turma-123/macro');
     expect(result).toEqual(mockData);
+  });
+
+  describe('buscarDesempenhoIndividual', () => {
+    it('deve fazer GET para /turmasDashboard/:id/individual e retornar os dados', async () => {
+      const mockData = {
+        alunos: [
+          {
+            alunoId: 'aluno-1',
+            totalRespondidas: 10,
+            totalAcertos: 8,
+            taxaAcerto: 80,
+            ultimaAtividade: '2026-05-30T10:00:00.000Z',
+            desempenhoPorTema: [],
+          },
+        ],
+      };
+
+      (httpClient.get as jest.Mock).mockResolvedValue({ data: mockData });
+
+      const result = await buscarDesempenhoIndividual('turma-123');
+
+      expect(httpClient.get).toHaveBeenCalledWith('/turmasDashboard/turma-123/individual');
+      expect(result).toEqual(mockData);
+    });
+
+    it('deve retornar lista vazia de alunos quando não há dados', async () => {
+      (httpClient.get as jest.Mock).mockResolvedValue({ data: { alunos: [] } });
+
+      const result = await buscarDesempenhoIndividual('turma-456');
+
+      expect(httpClient.get).toHaveBeenCalledWith('/turmasDashboard/turma-456/individual');
+      expect(result.alunos).toHaveLength(0);
+    });
   });
 });

--- a/src/entities/dashboardTurma/api/dashboardTurmaApi.test.ts
+++ b/src/entities/dashboardTurma/api/dashboardTurmaApi.test.ts
@@ -1,0 +1,21 @@
+import { buscarDashboardMacro } from './dashboardTurmaApi';
+import { httpClient } from '../../../shared/api/httpClient';
+
+jest.mock('../../../shared/api/httpClient', () => ({
+  httpClient: {
+    get: jest.fn(),
+  },
+}));
+
+describe('dashboardTurmaApi', () => {
+  it('deve chamar a API e retornar os dados do macro dashboard', async () => {
+    const mockData = { totalAlunos: 10, totalQuestoesRespondidas: 5, taxaMediaAcertos: 50, desempenhoPorTema: [] };
+    
+    (httpClient.get as jest.Mock).mockResolvedValue({ data: mockData });
+
+    const result = await buscarDashboardMacro('turma-123');
+
+    expect(httpClient.get).toHaveBeenCalledWith('/turmasDashboard/turma-123/macro');
+    expect(result).toEqual(mockData);
+  });
+});

--- a/src/entities/dashboardTurma/api/dashboardTurmaApi.ts
+++ b/src/entities/dashboardTurma/api/dashboardTurmaApi.ts
@@ -1,7 +1,12 @@
-import type { DashboardMacro } from '../model/types';
-import { httpClient } from '../../../shared/api/httpClient'; 
+import type { DashboardIndividual, DashboardMacro } from '../model/types';
+import { httpClient } from '../../../shared/api/httpClient';
 
 export const buscarDashboardMacro = async (turmaId: string): Promise<DashboardMacro> => {
   const { data } = await httpClient.get(`/turmasDashboard/${turmaId}/macro`);
+  return data;
+};
+
+export const buscarDesempenhoIndividual = async (turmaId: string): Promise<DashboardIndividual> => {
+  const { data } = await httpClient.get(`/turmasDashboard/${turmaId}/individual`);
   return data;
 };

--- a/src/entities/dashboardTurma/api/dashboardTurmaApi.ts
+++ b/src/entities/dashboardTurma/api/dashboardTurmaApi.ts
@@ -1,0 +1,7 @@
+import type { DashboardMacro } from '../model/types';
+import { httpClient } from '../../../shared/api/httpClient'; 
+
+export const buscarDashboardMacro = async (turmaId: string): Promise<DashboardMacro> => {
+  const { data } = await httpClient.get(`/turmasDashboard/${turmaId}/macro`);
+  return data;
+};

--- a/src/entities/dashboardTurma/model/types.ts
+++ b/src/entities/dashboardTurma/model/types.ts
@@ -1,0 +1,15 @@
+export type StatusDesempenho = 'Tranquilo' | 'Atenção' | 'Crítico';
+
+export interface TemaDesempenho {
+  nome: string;
+  totalRespondidas: number;
+  taxaAcerto: number;
+  status: StatusDesempenho;
+}
+
+export interface DashboardMacro {
+  totalAlunos: number;
+  totalQuestoesRespondidas: number;
+  taxaMediaAcertos: number;
+  desempenhoPorTema: TemaDesempenho[];
+}

--- a/src/entities/dashboardTurma/model/types.ts
+++ b/src/entities/dashboardTurma/model/types.ts
@@ -13,3 +13,16 @@ export interface DashboardMacro {
   taxaMediaAcertos: number;
   desempenhoPorTema: TemaDesempenho[];
 }
+
+export interface DesempenhoAluno {
+  alunoId: string;
+  totalRespondidas: number;
+  totalAcertos: number;
+  taxaAcerto: number;
+  ultimaAtividade: string | null;
+  desempenhoPorTema: TemaDesempenho[];
+}
+
+export interface DashboardIndividual {
+  alunos: DesempenhoAluno[];
+}

--- a/src/entities/turmas/api/turmaApi.ts
+++ b/src/entities/turmas/api/turmaApi.ts
@@ -64,3 +64,9 @@ export const vincularAlunoTurma = async (turmaId: string, alunoId: string) => {
 export const desvincularAlunoTurma = async (turmaId: string, alunoId: string) => {
   await httpClient.delete(`/turmas/${turmaId}/alunos/${alunoId}`);
 };
+
+
+export const buscarTurmaPorId = async (id: string) => {
+  const response = await httpClient.get<RespostaApi<TurmaApi>>(`/turmas/${id}`);
+  return normalizarTurma(response.data.dados);
+};

--- a/src/features/dashboard-turmas/ui/CardsResumo.test.tsx
+++ b/src/features/dashboard-turmas/ui/CardsResumo.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { CardsResumo } from './CardsResumo';
+
+describe('CardsResumo', () => {
+  it('deve renderizar os dados corretamente quando há questões respondidas', () => {
+    const mockDados = {
+      totalAlunos: 25,
+      totalQuestoesRespondidas: 150,
+      taxaMediaAcertos: 85,
+      desempenhoPorTema: []
+    };
+
+    render(<CardsResumo dados={mockDados} />);
+
+    expect(screen.getByText('25')).toBeInTheDocument();
+    expect(screen.getByText('150')).toBeInTheDocument();
+    expect(screen.getByText('85%')).toBeInTheDocument();
+  });
+
+  it('deve exibir hífen para taxa de acertos quando não houver questões respondidas', () => {
+    const mockDados = {
+      totalAlunos: 25,
+      totalQuestoesRespondidas: 0, 
+      taxaMediaAcertos: 0,
+      desempenhoPorTema: []
+    };
+
+    render(<CardsResumo dados={mockDados} />);
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard-turmas/ui/CardsResumo.tsx
+++ b/src/features/dashboard-turmas/ui/CardsResumo.tsx
@@ -1,0 +1,44 @@
+import { Users, Clock, CheckCircle2 } from 'lucide-react';
+import type { DashboardMacro } from '../../../entities/dashboardTurma/model/types';
+
+interface CardsResumoProps {
+  dados: DashboardMacro;
+}
+
+export const CardsResumo = ({ dados }: CardsResumoProps) => {
+  return (
+    <div className="mb-6 grid grid-cols-1 gap-6 md:grid-cols-3">
+      <div className="flex items-center gap-4 rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
+        <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-blue-50 text-blue-500">
+          <Users size={28} />
+        </div>
+        <div>
+          <p className="text-3xl font-bold text-gray-900">{dados.totalAlunos}</p>
+          <p className="text-xs font-medium text-gray-500">Alunos matriculados<br/>na turma</p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4 rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
+        <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-teal-50 text-teal-500">
+          <Clock size={28} />
+        </div>
+        <div>
+          <p className="text-3xl font-bold text-gray-900">{dados.totalQuestoesRespondidas}</p>
+          <p className="text-xs font-medium text-gray-500">Questões respondidas<br/>pela turma no total</p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4 rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
+        <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-green-50 text-green-500">
+          <CheckCircle2 size={28} />
+        </div>
+        <div>
+          <p className="text-3xl font-bold text-gray-900">
+            {dados.totalQuestoesRespondidas > 0 ? `${dados.taxaMediaAcertos}%` : '-'}
+          </p>
+          <p className="text-xs font-medium text-gray-500">Taxa média de acertos<br/>da turma inteira</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/dashboard-turmas/ui/EmptyState.test.tsx
+++ b/src/features/dashboard-turmas/ui/EmptyState.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  it('deve renderizar os textos corretamente', () => {
+    render(<EmptyState />);
+    
+    expect(screen.getByText('Ainda não há dados suficientes')).toBeInTheDocument();
+    expect(screen.getByText(/Incentive seus alunos a praticarem as listas/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard-turmas/ui/EmptyState.tsx
+++ b/src/features/dashboard-turmas/ui/EmptyState.tsx
@@ -1,0 +1,13 @@
+import { Activity } from 'lucide-react';
+
+export const EmptyState = () => (
+  <div className="flex h-64 flex-col items-center justify-center rounded-xl border border-gray-100 bg-white p-6 text-center shadow-sm">
+    <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-gray-50 text-gray-400">
+      <Activity size={32} />
+    </div>
+    <h3 className="mb-2 text-lg font-bold text-gray-900">Ainda não há dados suficientes</h3>
+    <p className="max-w-md text-sm text-gray-500">
+      Incentive seus alunos a praticarem as listas! Os gráficos de desempenho aparecerão assim que os primeiros exercícios forem respondidos.
+    </p>
+  </div>
+);

--- a/src/features/dashboard-turmas/ui/GraficoTemas.test.tsx
+++ b/src/features/dashboard-turmas/ui/GraficoTemas.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { GraficoTemas } from './GraficoTemas';
+import type { TemaDesempenho } from '../../../entities/dashboardTurma/model/types';
+
+describe('GraficoTemas', () => {
+  it('deve renderizar a lista de temas com suas respectivas taxas e status de cores', () => {
+    const mockTemas: TemaDesempenho[] = [
+      { nome: 'Neuroanatomia', totalRespondidas: 10, taxaAcerto: 80, status: 'Tranquilo' as const },
+      { nome: 'Abdome Agudo', totalRespondidas: 5, taxaAcerto: 50, status: 'Atenção' as const },
+      { nome: 'Esqueleto', totalRespondidas: 8, taxaAcerto: 20, status: 'Crítico' as const },
+      { nome: 'Tema Desconhecido', totalRespondidas: 0, taxaAcerto: 0, status: 'Outro' as unknown as TemaDesempenho['status'] }, 
+    ];
+
+    render(<GraficoTemas temas={mockTemas} />);
+
+    expect(screen.getByText('Neuroanatomia')).toBeInTheDocument();
+    expect(screen.getByText('80%')).toBeInTheDocument();
+    expect(screen.getByText('Tranquilo')).toBeInTheDocument();
+
+    expect(screen.getByText('Abdome Agudo')).toBeInTheDocument();
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('Atenção')).toBeInTheDocument();
+
+    expect(screen.getByText('Esqueleto')).toBeInTheDocument();
+    expect(screen.getByText('20%')).toBeInTheDocument();
+    expect(screen.getByText('Crítico')).toBeInTheDocument();
+    
+    expect(screen.getByText('Tema Desconhecido')).toBeInTheDocument();
+    expect(screen.getByText('Outro')).toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard-turmas/ui/GraficoTemas.tsx
+++ b/src/features/dashboard-turmas/ui/GraficoTemas.tsx
@@ -1,0 +1,66 @@
+import { BarChart3 } from 'lucide-react';
+import type { TemaDesempenho } from '../../../entities/dashboardTurma/model/types';
+
+interface GraficoTemasProps {
+  temas: TemaDesempenho[];
+}
+
+export const GraficoTemas = ({ temas }: GraficoTemasProps) => {
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'Tranquilo': return 'bg-green-500 text-green-700 bg-green-100';
+      case 'Atenção': return 'bg-amber-500 text-amber-700 bg-amber-100';
+      case 'Crítico': return 'bg-red-500 text-red-700 bg-red-100';
+      default: return 'bg-gray-500 text-gray-700 bg-gray-100';
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
+      <div className="mb-6 flex items-center justify-between border-b border-gray-100 pb-4">
+        <h3 className="flex items-center gap-2 font-bold text-gray-900">
+          <BarChart3 size={20} className="text-gray-400" />
+          Desempenho por Tema
+        </h3>
+        <span className="text-xs text-gray-400">ordenado por dificuldade</span>
+      </div>
+
+      <div className="space-y-5">
+        {/* Cabeçalho da listagem (Taxa de acerto por tema) */}
+        <div className="flex items-center justify-between text-xs font-semibold text-gray-900">
+           <span>Taxa de acerto por tema</span>
+        </div>
+
+        {temas.map((tema) => {
+          const colors = getStatusColor(tema.status).split(' ');
+          const barColor = colors[0];
+          const textColor = colors[1];
+          const badgeBg = colors[2];
+
+          return (
+            <div key={tema.nome} className="flex items-center gap-4">
+              <span className="w-1/3 truncate text-sm font-bold text-gray-700">
+                {tema.nome}
+              </span>
+              <div className="flex-1">
+                {/* Barra de progresso mais fina */}
+                <div className="h-2 w-full rounded-full bg-gray-100">
+                  <div
+                    className={`h-2 rounded-full ${barColor}`}
+                    style={{ width: `${tema.taxaAcerto}%` }}
+                  ></div>
+                </div>
+              </div>
+              <div className="flex w-24 items-center justify-between">
+                <span className="text-sm font-bold text-green-500">{tema.taxaAcerto}%</span>
+                <span className={`rounded px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${textColor} ${badgeBg}`}>
+                  {tema.status}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.test.tsx
+++ b/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.test.tsx
@@ -142,4 +142,69 @@ describe('TabelaDesempenhoIndividual', () => {
 
     expect(screen.getByText('Nenhuma questão respondida ainda.')).toBeInTheDocument();
   });
+
+  it('deve formatar a última atividade como "Hoje", "Ontem", data antiga e traço', async () => {
+    const agora = new Date();
+    const ontem = new Date(agora);
+    ontem.setDate(agora.getDate() - 1);
+
+    mockBuscarIndividual.mockResolvedValue({
+      alunos: [
+        { ...alunoStats, alunoId: 'a-hoje', ultimaAtividade: agora.toISOString() },
+        { ...alunoStats, alunoId: 'a-ontem', ultimaAtividade: ontem.toISOString() },
+        { ...alunoStats, alunoId: 'a-antigo', ultimaAtividade: '2020-01-15T10:00:00.000Z' },
+        { ...alunoStats, alunoId: 'a-sem', ultimaAtividade: null },
+      ],
+    });
+    mockBuscarUsuarios.mockResolvedValue([]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    expect(await screen.findByText(/^Hoje,/)).toBeInTheDocument();
+    expect(screen.getByText(/^Ontem,/)).toBeInTheDocument();
+    expect(screen.getByText('15/01/2020')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('deve aplicar as faixas de cor para taxas alta, média e baixa', async () => {
+    mockBuscarIndividual.mockResolvedValue({
+      alunos: [
+        { ...alunoStats, alunoId: 'a-alta', taxaAcerto: 85 },
+        { ...alunoStats, alunoId: 'a-media', taxaAcerto: 50 },
+        { ...alunoStats, alunoId: 'a-baixa', taxaAcerto: 20 },
+      ],
+    });
+    mockBuscarUsuarios.mockResolvedValue([]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    expect(await screen.findByText('85%')).toBeInTheDocument();
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('20%')).toBeInTheDocument();
+  });
+
+  it('deve exibir "Aluno desconhecido" quando o usuário não é encontrado', async () => {
+    mockBuscarIndividual.mockResolvedValue({ alunos: [{ ...alunoStats, alunoId: 'sem-usuario' }] });
+    mockBuscarUsuarios.mockResolvedValue([]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    expect(await screen.findByText('Aluno desconhecido')).toBeInTheDocument();
+    expect(screen.getByText('sem-usuario')).toBeInTheDocument();
+  });
+
+  it('deve logar erro no console quando a busca falha', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const erro = new Error('Falha de rede');
+    mockBuscarIndividual.mockRejectedValue(erro);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith('Erro ao carregar desempenho individual:', erro);
+    });
+
+    expect(await screen.findByText('Nenhum aluno encontrado na turma.')).toBeInTheDocument();
+    consoleSpy.mockRestore();
+  });
 });

--- a/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.test.tsx
+++ b/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TabelaDesempenhoIndividual } from './TabelaDesempenhoIndividual';
+import { buscarDesempenhoIndividual } from '../../../entities/dashboardTurma/api/dashboardTurmaApi';
+import { buscarUsuariosPorIds } from '../../../entities/usuarios/api/usuarioApi';
+
+jest.mock('../../../entities/dashboardTurma/api/dashboardTurmaApi', () => ({
+  buscarDesempenhoIndividual: jest.fn(),
+}));
+
+jest.mock('../../../entities/usuarios/api/usuarioApi', () => ({
+  buscarUsuariosPorIds: jest.fn(),
+}));
+
+const mockBuscarIndividual = buscarDesempenhoIndividual as jest.Mock;
+const mockBuscarUsuarios = buscarUsuariosPorIds as jest.Mock;
+
+const alunoUsuario = {
+  id: 'aluno-1',
+  nome: 'João Silva',
+  email: 'joao.silva@aluno.unb.br',
+  nickname: null,
+  perfil: 'ALUNO' as const,
+  status: 'ATIVO' as const,
+  instituicao: 'UnB',
+  curso: 'Medicina',
+  semestre: '2026.1',
+};
+
+const alunoStats = {
+  alunoId: 'aluno-1',
+  totalRespondidas: 48,
+  totalAcertos: 41,
+  taxaAcerto: 85,
+  ultimaAtividade: null,
+  desempenhoPorTema: [
+    { nome: 'Tórax', totalRespondidas: 20, taxaAcerto: 90, status: 'Tranquilo' as const },
+  ],
+};
+
+describe('TabelaDesempenhoIndividual', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve exibir estado de carregamento enquanto busca os dados', () => {
+    mockBuscarIndividual.mockReturnValue(new Promise(() => {}));
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    expect(screen.getByText('Carregando desempenho individual...')).toBeInTheDocument();
+  });
+
+  it('deve exibir mensagem quando não há alunos na turma', async () => {
+    mockBuscarIndividual.mockResolvedValue({ alunos: [] });
+    mockBuscarUsuarios.mockResolvedValue([]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    expect(await screen.findByText('Nenhum aluno encontrado na turma.')).toBeInTheDocument();
+  });
+
+  it('deve renderizar a tabela com dados do aluno', async () => {
+    mockBuscarIndividual.mockResolvedValue({ alunos: [alunoStats] });
+    mockBuscarUsuarios.mockResolvedValue([alunoUsuario]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    expect(await screen.findByText('João Silva')).toBeInTheDocument();
+    expect(screen.getByText('joao.silva@aluno.unb.br')).toBeInTheDocument();
+    expect(screen.getByText('48')).toBeInTheDocument();
+    expect(screen.getByText('85%')).toBeInTheDocument();
+  });
+
+  it('deve chamar as APIs corretas ao montar', async () => {
+    mockBuscarIndividual.mockResolvedValue({ alunos: [alunoStats] });
+    mockBuscarUsuarios.mockResolvedValue([alunoUsuario]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    await screen.findByText('João Silva');
+
+    expect(mockBuscarIndividual).toHaveBeenCalledWith('turma-123');
+    expect(mockBuscarUsuarios).toHaveBeenCalledWith(['aluno-1']);
+  });
+
+  it('deve abrir o modal ao clicar em um aluno', async () => {
+    const user = userEvent.setup();
+    mockBuscarIndividual.mockResolvedValue({ alunos: [alunoStats] });
+    mockBuscarUsuarios.mockResolvedValue([alunoUsuario]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    await user.click(await screen.findByText('João Silva'));
+
+    expect(screen.getByText('Desempenho por Tema')).toBeInTheDocument();
+    expect(screen.getByText('Tórax')).toBeInTheDocument();
+    expect(screen.getByText('90%')).toBeInTheDocument();
+  });
+
+  it('deve exibir os cards de resumo no modal', async () => {
+    const user = userEvent.setup();
+    mockBuscarIndividual.mockResolvedValue({ alunos: [alunoStats] });
+    mockBuscarUsuarios.mockResolvedValue([alunoUsuario]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    await user.click(await screen.findByText('João Silva'));
+
+    expect(screen.getByText('41')).toBeInTheDocument();
+    expect(screen.getAllByText('85%')).toHaveLength(2);
+  });
+
+  it('deve fechar o modal ao clicar no botão de fechar', async () => {
+    const user = userEvent.setup();
+    mockBuscarIndividual.mockResolvedValue({ alunos: [alunoStats] });
+    mockBuscarUsuarios.mockResolvedValue([alunoUsuario]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    await user.click(await screen.findByText('João Silva'));
+
+    expect(screen.getByText('Desempenho por Tema')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Fechar detalhes do aluno' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Desempenho por Tema')).not.toBeInTheDocument();
+    });
+  });
+
+  it('deve exibir mensagem quando o aluno não tem temas respondidos no modal', async () => {
+    const user = userEvent.setup();
+    mockBuscarIndividual.mockResolvedValue({
+      alunos: [{ ...alunoStats, desempenhoPorTema: [] }],
+    });
+    mockBuscarUsuarios.mockResolvedValue([alunoUsuario]);
+
+    render(<TabelaDesempenhoIndividual turmaId="turma-123" />);
+
+    await user.click(await screen.findByText('João Silva'));
+
+    expect(screen.getByText('Nenhuma questão respondida ainda.')).toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.tsx
+++ b/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useState } from 'react';
+import { BarChart3, X } from 'lucide-react';
+import { buscarDesempenhoIndividual } from '../../../entities/dashboardTurma/api/dashboardTurmaApi';
+import { buscarUsuariosPorIds } from '../../../entities/usuarios/api/usuarioApi';
+import type { DesempenhoAluno } from '../../../entities/dashboardTurma/model/types';
+import type { UsuarioResumo } from '../../../entities/usuarios/model/types';
+
+type AlunoComDesempenho = DesempenhoAluno & { usuario: UsuarioResumo | null };
+
+interface Props {
+  turmaId: string;
+}
+
+const AVATAR_COLORS = [
+  'bg-teal-500',
+  'bg-blue-500',
+  'bg-purple-500',
+  'bg-orange-500',
+  'bg-pink-500',
+  'bg-indigo-500',
+  'bg-rose-500',
+  'bg-cyan-500',
+];
+
+function avatarColor(id: string): string {
+  const hash = id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+}
+
+function initials(nome: string): string {
+  const parts = nome.trim().split(' ').filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function formatarData(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  const hoje = new Date();
+  const ontem = new Date(hoje);
+  ontem.setDate(hoje.getDate() - 1);
+
+  const mesmodia = (a: Date, b: Date) =>
+    a.getDate() === b.getDate() && a.getMonth() === b.getMonth() && a.getFullYear() === b.getFullYear();
+
+  const hh = d.getHours();
+  const mm = String(d.getMinutes()).padStart(2, '0');
+
+  if (mesmodia(d, hoje)) return `Hoje, ${hh}h${mm}`;
+  if (mesmodia(d, ontem)) return `Ontem, ${hh}h${mm}`;
+  return d.toLocaleDateString('pt-BR');
+}
+
+function barColor(taxa: number): string {
+  if (taxa >= 70) return 'bg-green-500';
+  if (taxa >= 40) return 'bg-amber-500';
+  return 'bg-red-500';
+}
+
+function textColor(taxa: number): string {
+  if (taxa >= 70) return 'text-green-600';
+  if (taxa >= 40) return 'text-amber-600';
+  return 'text-red-600';
+}
+
+export const TabelaDesempenhoIndividual = ({ turmaId }: Props) => {
+  const [alunos, setAlunos] = useState<AlunoComDesempenho[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selected, setSelected] = useState<AlunoComDesempenho | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+        const individual = await buscarDesempenhoIndividual(turmaId);
+        const ids = individual.alunos.map((a) => a.alunoId);
+        const usuarios = ids.length > 0 ? await buscarUsuariosPorIds(ids) : [];
+        const porId = new Map(usuarios.map((u) => [u.id, u]));
+
+        setAlunos(
+          individual.alunos.map((stats) => ({
+            ...stats,
+            usuario: porId.get(stats.alunoId) ?? null,
+          })),
+        );
+      } catch (err) {
+        console.error('Erro ao carregar desempenho individual:', err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void fetchData();
+  }, [turmaId]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-48 items-center justify-center text-sm text-gray-400">
+        Carregando desempenho individual...
+      </div>
+    );
+  }
+
+  if (alunos.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-sm text-gray-400">
+        Nenhum aluno encontrado na turma.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-4 flex items-center justify-between">
+        <span className="text-sm font-semibold text-gray-700">Alunos da turma</span>
+        <span className="text-xs text-gray-400">clique em um aluno para ver histórico detalhado</span>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-100">
+              <th className="pb-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-400">Aluno</th>
+              <th className="pb-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-400">
+                Questões Respondidas
+              </th>
+              <th className="pb-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-400">
+                Taxa de Acerto
+              </th>
+              <th className="pb-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-400">
+                Última Atividade
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-50">
+            {alunos.map((aluno) => {
+              const nome = aluno.usuario?.nome ?? 'Aluno desconhecido';
+              const email = aluno.usuario?.email ?? aluno.alunoId;
+
+              return (
+                <tr
+                  key={aluno.alunoId}
+                  onClick={() => setSelected(aluno)}
+                  className="cursor-pointer transition-colors hover:bg-gray-50"
+                >
+                  <td className="py-4 pr-4">
+                    <div className="flex items-center gap-3">
+                      <div
+                        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white ${avatarColor(aluno.alunoId)}`}
+                      >
+                        {initials(nome)}
+                      </div>
+                      <div>
+                        <p className="font-semibold text-gray-900">{nome}</p>
+                        <p className="text-xs text-gray-400">{email}</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="py-4 pr-4 font-semibold text-gray-900">{aluno.totalRespondidas}</td>
+                  <td className="py-4 pr-4">
+                    <div className="flex items-center gap-3">
+                      <div className="h-2 w-28 rounded-full bg-gray-100">
+                        <div
+                          className={`h-2 rounded-full ${barColor(aluno.taxaAcerto)}`}
+                          style={{ width: `${aluno.taxaAcerto}%` }}
+                        />
+                      </div>
+                      <span className={`text-sm font-bold ${textColor(aluno.taxaAcerto)}`}>
+                        {aluno.taxaAcerto}%
+                      </span>
+                    </div>
+                  </td>
+                  <td className="py-4 text-gray-500">{formatarData(aluno.ultimaAtividade)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {selected && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm">
+          <div className="w-full max-w-xl rounded-xl bg-white p-6 shadow-xl">
+            <div className="mb-5 flex items-start justify-between">
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white ${avatarColor(selected.alunoId)}`}
+                >
+                  {initials(selected.usuario?.nome ?? '?')}
+                </div>
+                <div>
+                  <h3 className="font-bold text-gray-900">{selected.usuario?.nome ?? 'Aluno'}</h3>
+                  <p className="text-sm text-gray-400">{selected.usuario?.email}</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelected(null)}
+                className="rounded-lg p-2 text-gray-400 hover:bg-gray-100"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="mb-5 grid grid-cols-3 gap-3">
+              <div className="rounded-lg bg-gray-50 p-3 text-center">
+                <p className="text-lg font-bold text-gray-900">{selected.totalRespondidas}</p>
+                <p className="text-xs text-gray-500">Questões</p>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-3 text-center">
+                <p className="text-lg font-bold text-green-600">{selected.totalAcertos}</p>
+                <p className="text-xs text-gray-500">Acertos</p>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-3 text-center">
+                <p className={`text-lg font-bold ${textColor(selected.taxaAcerto)}`}>{selected.taxaAcerto}%</p>
+                <p className="text-xs text-gray-500">Taxa Geral</p>
+              </div>
+            </div>
+
+            {selected.desempenhoPorTema.length > 0 ? (
+              <>
+                <div className="mb-3 flex items-center gap-2">
+                  <BarChart3 size={16} className="text-gray-400" />
+                  <span className="text-sm font-bold text-gray-700">Desempenho por Tema</span>
+                </div>
+                <div className="max-h-64 space-y-3 overflow-y-auto">
+                  {selected.desempenhoPorTema.map((tema) => (
+                    <div key={tema.nome} className="flex items-center gap-3">
+                      <span className="w-1/3 truncate text-sm font-medium text-gray-700">{tema.nome}</span>
+                      <div className="flex-1">
+                        <div className="h-2 w-full rounded-full bg-gray-100">
+                          <div
+                            className={`h-2 rounded-full ${barColor(tema.taxaAcerto)}`}
+                            style={{ width: `${tema.taxaAcerto}%` }}
+                          />
+                        </div>
+                      </div>
+                      <span className={`w-10 text-right text-sm font-bold ${textColor(tema.taxaAcerto)}`}>
+                        {tema.taxaAcerto}%
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <p className="text-center text-sm text-gray-400">Nenhuma questão respondida ainda.</p>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.tsx
+++ b/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.tsx
@@ -196,6 +196,7 @@ export const TabelaDesempenhoIndividual = ({ turmaId }: Props) => {
               </div>
               <button
                 type="button"
+                aria-label="Fechar detalhes do aluno"
                 onClick={() => setSelected(null)}
                 className="rounded-lg p-2 text-gray-400 hover:bg-gray-100"
               >

--- a/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.tsx
+++ b/src/features/dashboard-turmas/ui/TabelaDesempenhoIndividual.tsx
@@ -23,7 +23,7 @@ const AVATAR_COLORS = [
 ];
 
 function avatarColor(id: string): string {
-  const hash = id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  const hash = id.split('').reduce((acc, c) => acc + (c.codePointAt(0) ?? 0), 0);
   return AVATAR_COLORS[hash % AVATAR_COLORS.length];
 }
 
@@ -31,7 +31,7 @@ function initials(nome: string): string {
   const parts = nome.trim().split(' ').filter(Boolean);
   if (parts.length === 0) return '?';
   if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  return (parts[0][0] + parts.at(-1)![0]).toUpperCase();
 }
 
 function formatarData(iso: string | null): string {

--- a/src/features/manage-turmas/ui/ListarTurmas.test.tsx
+++ b/src/features/manage-turmas/ui/ListarTurmas.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { ListaTurmas } from './ListarTurmas';
 import {
   atualizarTurma,
@@ -148,7 +149,7 @@ describe('ListaTurmas Feature', () => {
   });
 
   it('deve carregar e renderizar a lista de turmas na montagem inicial', async () => {
-    render(<ListaTurmas />);
+    render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
 
     await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(1));
     expect(listarTurmas).toHaveBeenCalledWith({
@@ -166,7 +167,7 @@ describe('ListaTurmas Feature', () => {
   it('deve mostrar mensagem de lista vazia quando nao houver turmas', async () => {
     (listarTurmas as jest.Mock).mockResolvedValue([]);
 
-    render(<ListaTurmas />);
+    render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
 
     expect(await screen.findByText('Nenhuma turma encontrada.')).toBeInTheDocument();
   });
@@ -175,7 +176,7 @@ describe('ListaTurmas Feature', () => {
     const erroMock = new Error('Falha na rede');
     (listarTurmas as jest.Mock).mockRejectedValue(erroMock);
 
-    render(<ListaTurmas />);
+    render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
 
     await waitFor(() => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Erro ao carregar turmas', erroMock);
@@ -186,7 +187,7 @@ describe('ListaTurmas Feature', () => {
   it('deve disparar nova busca ao digitar no campo de pesquisa', async () => {
     const user = userEvent.setup();
 
-    render(<ListaTurmas />);
+    render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
 
     const inputBusca = screen.getByPlaceholderText('Buscar turma');
     await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(1));
@@ -204,7 +205,7 @@ describe('ListaTurmas Feature', () => {
   it('deve disparar nova busca ao alterar filtros de ano, semestre e status', async () => {
     const user = userEvent.setup();
 
-    render(<ListaTurmas />);
+    render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
     await waitFor(() => expect(listarTurmas).toHaveBeenCalledTimes(1));
     jest.clearAllMocks();
 
@@ -226,7 +227,7 @@ describe('ListaTurmas Feature', () => {
     const user = userEvent.setup();
     (criarTurma as jest.Mock).mockResolvedValue(mockTurmas[0]);
 
-    render(<ListaTurmas />);
+    render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
     await screen.findByText('Anatomia Sistemica');
 
     await user.click(screen.getByRole('button', { name: /Nova Turma/i }));
@@ -244,7 +245,7 @@ describe('ListaTurmas Feature', () => {
     const user = userEvent.setup();
     (atualizarTurma as jest.Mock).mockResolvedValue(mockTurmas[0]);
 
-    render(<ListaTurmas />);
+    render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
     await screen.findByText('Anatomia Sistemica');
 
     await user.click(screen.getAllByRole('button', { name: /Editar/i })[0]);
@@ -262,7 +263,7 @@ describe('ListaTurmas Feature', () => {
   it('deve abrir modal de alunos e atualizar listagem apos alteracao', async () => {
     const user = userEvent.setup();
 
-    render(<ListaTurmas />);
+    render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
     await screen.findByText('Anatomia Sistemica');
 
     await user.click(screen.getAllByRole('button', { name: /Alunos/i })[0]);
@@ -278,7 +279,7 @@ describe('ListaTurmas Feature', () => {
     it('deve abrir o modal ao clicar em excluir e permitir cancelar', async () => {
       const user = userEvent.setup();
 
-      render(<ListaTurmas />);
+      render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
       await screen.findByText('Anatomia Sistemica');
 
       await user.click(screen.getAllByRole('button', { name: /Excluir/i })[0]);
@@ -295,7 +296,7 @@ describe('ListaTurmas Feature', () => {
       const user = userEvent.setup();
       (excluirTurma as jest.Mock).mockResolvedValue(undefined);
 
-      render(<ListaTurmas />);
+      render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
       await screen.findByText('Anatomia Sistemica');
 
       await user.click(screen.getAllByRole('button', { name: /Excluir/i })[0]);
@@ -312,7 +313,7 @@ describe('ListaTurmas Feature', () => {
       const erroExclusao = new Error('Falha ao excluir');
       (excluirTurma as jest.Mock).mockRejectedValue(erroExclusao);
 
-      render(<ListaTurmas />);
+      render(<MemoryRouter><ListaTurmas /></MemoryRouter>);
       await screen.findByText('Anatomia Sistemica');
 
       await user.click(screen.getAllByRole('button', { name: /Excluir/i })[0]);

--- a/src/features/manage-turmas/ui/ListarTurmas.tsx
+++ b/src/features/manage-turmas/ui/ListarTurmas.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AlertCircle, CheckCircle2, Edit, Plus, Search, Trash2, Users } from 'lucide-react';
 import type { SalvarTurmaPayload, StatusTurma, Turma } from '../../../entities/turmas/model/types';
+import { Link} from 'react-router-dom'; 
 import {
   atualizarTurma,
   criarTurma,
@@ -248,7 +249,11 @@ export const ListaTurmas = () => {
           <tbody className="divide-y divide-gray-200">
             {turmas.map((turma) => (
               <tr key={turma.id} className="hover:bg-gray-50/50">
-                <td className="px-6 py-4 font-bold text-gray-900">{turma.nome}</td>
+                <td className="px-6 py-4 font-bold text-gray-900">
+                  <Link to={`/turmas/${turma.id}`} className="hover:text-teal-600 hover:underline">
+                    {turma.nome}
+                  </Link>
+                </td>
                 <td className="px-6 py-4">{turma.ano}.{turma.semestre}</td>
                 <td className="px-6 py-4">{turma.descricao}</td>
                 <td className="px-6 py-4">

--- a/src/pages/TurmaDetalhes/index.ts
+++ b/src/pages/TurmaDetalhes/index.ts
@@ -1,0 +1,1 @@
+export {TurmaDetalhesPage} from './ui/TurmaDetalhesPage'

--- a/src/pages/TurmaDetalhes/ui/TurmaDetalhesPage.test.tsx
+++ b/src/pages/TurmaDetalhes/ui/TurmaDetalhesPage.test.tsx
@@ -11,6 +11,11 @@ jest.mock('../../../entities/turmas/api/turmaApi', () => ({
 
 jest.mock('../../../entities/dashboardTurma/api/dashboardTurmaApi', () => ({
   buscarDashboardMacro: jest.fn(),
+  buscarDesempenhoIndividual: jest.fn(),
+}));
+
+jest.mock('../../../entities/usuarios/api/usuarioApi', () => ({
+  buscarUsuariosPorIds: jest.fn(),
 }));
 
 const mockTurma = {

--- a/src/pages/TurmaDetalhes/ui/TurmaDetalhesPage.test.tsx
+++ b/src/pages/TurmaDetalhes/ui/TurmaDetalhesPage.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { TurmaDetalhesPage } from '../index'; 
+import { buscarTurmaPorId } from '../../../entities/turmas/api/turmaApi';
+import { buscarDashboardMacro } from '../../../entities/dashboardTurma/api/dashboardTurmaApi';
+
+jest.mock('../../../entities/turmas/api/turmaApi', () => ({
+  buscarTurmaPorId: jest.fn(),
+}));
+
+jest.mock('../../../entities/dashboardTurma/api/dashboardTurmaApi', () => ({
+  buscarDashboardMacro: jest.fn(),
+}));
+
+const mockTurma = {
+  id: 'turma-123',
+  nome: 'Turma A',
+  ano: 2026,
+  semestre: '1',
+  quantidadeAlunos: 15,
+  status: 'ATIVA',
+};
+
+const mockDashboard = {
+  totalAlunos: 15,
+  totalQuestoesRespondidas: 50,
+  taxaMediaAcertos: 75,
+  desempenhoPorTema: [],
+};
+
+const renderWithRouter = () => {
+  return render(
+    <MemoryRouter initialEntries={['/turmas/turma-123']}>
+      <Routes>
+        <Route path="/turmas/:id" element={<TurmaDetalhesPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('TurmaDetalhesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve exibir o estado de carregamento inicialmente', () => {
+    (buscarTurmaPorId as jest.Mock).mockImplementation(() => new Promise(() => {}));
+    (buscarDashboardMacro as jest.Mock).mockImplementation(() => new Promise(() => {}));
+
+    renderWithRouter();
+    expect(screen.getByText('Carregando detalhes da turma...')).toBeInTheDocument();
+  });
+
+  it('deve exibir mensagem de erro se a turma não for encontrada', async () => {
+    (buscarTurmaPorId as jest.Mock).mockResolvedValue(null);
+    (buscarDashboardMacro as jest.Mock).mockResolvedValue(null);
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByText('Turma não encontrada.')).toBeInTheDocument();
+    });
+  });
+
+  it('deve renderizar os dados da turma e o dashboard com sucesso', async () => {
+    (buscarTurmaPorId as jest.Mock).mockResolvedValue(mockTurma);
+    (buscarDashboardMacro as jest.Mock).mockResolvedValue(mockDashboard);
+
+    renderWithRouter();
+
+    expect(await screen.findByRole('heading', { name: 'Turma A' })).toBeInTheDocument();
+    expect(screen.getByText('2026.1')).toBeInTheDocument();
+    expect(screen.getByText('Ativa')).toBeInTheDocument();
+    
+    expect(screen.getByText('50')).toBeInTheDocument(); 
+  });
+
+  it('deve exibir o EmptyState se não houver questões respondidas', async () => {
+    (buscarTurmaPorId as jest.Mock).mockResolvedValue(mockTurma);
+    (buscarDashboardMacro as jest.Mock).mockResolvedValue({ 
+      ...mockDashboard, 
+      totalQuestoesRespondidas: 0 
+    });
+
+    renderWithRouter();
+
+    expect(await screen.findByText('Ainda não há dados suficientes')).toBeInTheDocument();
+
+    expect(screen.queryByText('Desempenho Individual')).not.toBeInTheDocument();
+  });
+
+  it('deve alternar entre as abas e esconder o dashboard', async () => {
+    const user = userEvent.setup();
+    (buscarTurmaPorId as jest.Mock).mockResolvedValue(mockTurma);
+    (buscarDashboardMacro as jest.Mock).mockResolvedValue(mockDashboard);
+
+    renderWithRouter();
+    await screen.findByRole('heading', { name: 'Turma A' });
+
+    const abaAlunos = screen.getByRole('button', { name: /Alunos/i });
+    
+    await user.click(abaAlunos);
+
+    expect(screen.queryByText('Desempenho Individual')).not.toBeInTheDocument();
+  });
+
+  it('deve exibir console.error em caso de falha na API', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const erroAPI = new Error('Falha de rede');
+    
+    (buscarTurmaPorId as jest.Mock).mockRejectedValue(erroAPI);
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith('Erro ao buscar dados:', erroAPI);
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/pages/TurmaDetalhes/ui/TurmaDetalhesPage.tsx
+++ b/src/pages/TurmaDetalhes/ui/TurmaDetalhesPage.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Users, Edit, LayoutList, Activity } from 'lucide-react';
+
+import { buscarDashboardMacro } from '../../../entities/dashboardTurma/api/dashboardTurmaApi';
+import { buscarTurmaPorId } from '../../../entities/turmas/api/turmaApi'; 
+
+import type { DashboardMacro } from '../../../entities/dashboardTurma/model/types';
+import type { Turma } from '../../../entities/turmas/model/types';
+
+import { CardsResumo } from '../../../features/dashboard-turmas/ui/CardsResumo';
+import { GraficoTemas } from '../../../features/dashboard-turmas/ui/GraficoTemas';
+import { EmptyState } from '../../../features/dashboard-turmas/ui/EmptyState';
+
+export const TurmaDetalhesPage = () => {
+  const { id } = useParams<{ id: string }>();
+  
+  const [activeTab, setActiveTab] = useState<'alunos' | 'listas' | 'dashboard'>('dashboard');
+  const [dashboardData, setDashboardData] = useState<DashboardMacro | null>(null);
+  const [turma, setTurma] = useState<Turma | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!id) return;
+      try {
+        setIsLoading(true);
+        // Busca os dados da turma E do dashboard ao mesmo tempo
+        const [turmaResponse, dashResponse] = await Promise.all([
+          buscarTurmaPorId(id), 
+          buscarDashboardMacro(id)
+        ]);
+        
+        setTurma(turmaResponse);
+        setDashboardData(dashResponse);
+      } catch (error) {
+        console.error('Erro ao buscar dados:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  if (isLoading) {
+    return <div className="flex h-64 items-center justify-center text-gray-500">Carregando detalhes da turma...</div>;
+  }
+
+  if (!turma) {
+    return <div className="flex h-64 items-center justify-center text-red-500">Turma não encontrada.</div>;
+  }
+
+  return (
+    <div className="w-full p-6 md:p-8">
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Detalhes da Turma</h1>
+          <p className="text-sm text-gray-500">Visão completa de alunos, listas e desempenho</p>
+        </div>
+        
+        <div className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-1.5 text-sm font-medium text-gray-600 shadow-sm">
+          <Users size={16} /> Professor
+          <div className="flex h-6 w-6 items-center justify-center rounded bg-teal-500 text-xs font-bold text-white">PS</div>
+        </div>
+      </div>
+
+      <div className="mb-4 text-xs font-medium text-gray-400">
+        <Link to="/turmas" className="hover:text-teal-500">Turmas</Link> &gt; <span className="text-gray-600">{turma.nome}</span>
+      </div>
+
+      <div className="mb-6 rounded-xl border border-gray-100 bg-white pt-6 shadow-sm">
+        <div className="px-6 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-teal-500 text-white shadow-md shadow-teal-200">
+              <Users size={28} />
+            </div>
+            <div>
+              <h2 className="text-xl font-bold text-gray-900">{turma.nome}</h2>
+              <div className="mt-1 flex items-center gap-2 text-xs font-semibold text-gray-400">
+                <span>{turma.ano}.{turma.semestre}</span>
+                <span>•</span>
+                <span>{turma.quantidadeAlunos ?? 0} alunos</span>
+                <span>•</span>
+                <span>Prof. Responsável</span>
+                <span>•</span>
+                <span className={`flex items-center gap-1 ${turma.status === 'ATIVA' ? 'text-teal-600' : 'text-amber-600'}`}>
+                  <span className={`h-2 w-2 rounded-full ${turma.status === 'ATIVA' ? 'bg-teal-500' : 'bg-amber-500'}`}></span>
+                  {turma.status === 'ATIVA' ? 'Ativa' : 'Inativa'}
+                </span>
+              </div>
+            </div>
+          </div>
+          
+          <button className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-bold text-gray-700 shadow-sm transition-colors hover:bg-gray-50">
+            <Edit size={16} />
+            Editar turma
+          </button>
+        </div>
+
+        <div className="mt-6 flex border-t border-gray-100 px-6">
+          <button 
+            onClick={() => setActiveTab('alunos')}
+            className={`flex items-center gap-2 border-b-2 px-4 py-4 text-sm font-bold transition-colors ${activeTab === 'alunos' ? 'border-teal-500 text-teal-600' : 'border-transparent text-gray-400 hover:text-gray-700'}`}
+          >
+            <Users size={18} /> Alunos
+          </button>
+          <button 
+            onClick={() => setActiveTab('listas')}
+            className={`flex items-center gap-2 border-b-2 px-4 py-4 text-sm font-bold transition-colors ${activeTab === 'listas' ? 'border-teal-500 text-teal-600' : 'border-transparent text-gray-400 hover:text-gray-700'}`}
+          >
+            <LayoutList size={18} /> Listas
+          </button>
+          <button 
+            onClick={() => setActiveTab('dashboard')}
+            className={`flex items-center gap-2 border-b-2 px-4 py-4 text-sm font-bold transition-colors ${activeTab === 'dashboard' ? 'border-teal-500 text-teal-600' : 'border-transparent text-gray-400 hover:text-gray-700'}`}
+          >
+            <Activity size={18} /> Dashboard
+          </button>
+        </div>
+      </div>
+
+      {activeTab === 'dashboard' && dashboardData && (
+        <>
+          <CardsResumo dados={dashboardData} />
+
+          {dashboardData.totalQuestoesRespondidas === 0 ? (
+            <EmptyState />
+          ) : (
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+              
+              <div className="flex flex-col gap-6 lg:col-span-8">
+                {/* A sua parte: Temas */}
+                <GraficoTemas temas={dashboardData.desempenhoPorTema} />
+                
+                <div className="rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
+                  <h3 className="mb-4 flex items-center gap-2 font-bold text-gray-900">
+                    <Users size={20} className="text-gray-400" />
+                    Desempenho Individual
+                  </h3>
+                  <div className="flex h-48 items-center justify-center rounded-lg border-2 border-dashed border-gray-200 bg-gray-50 text-sm text-gray-400">
+                    [ Área reservada para a dupla: Tabela de Alunos (Visão Micro) ]
+                  </div>
+                </div>
+              </div>
+
+              <div className="lg:col-span-4">
+                <div className="h-full rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
+                  <h3 className="mb-4 flex items-center gap-2 font-bold text-gray-900">
+                    <LayoutList size={20} className="text-gray-400" />
+                    Desempenho por Lista
+                  </h3>
+                  <div className="flex h-64 items-center justify-center rounded-lg border-2 border-dashed border-gray-200 bg-gray-50 text-sm text-gray-400 text-center px-4">
+                    [ Área reservada para a dupla:<br/>Listas Vinculadas ]
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/pages/TurmaDetalhes/ui/TurmaDetalhesPage.tsx
+++ b/src/pages/TurmaDetalhes/ui/TurmaDetalhesPage.tsx
@@ -11,6 +11,7 @@ import type { Turma } from '../../../entities/turmas/model/types';
 import { CardsResumo } from '../../../features/dashboard-turmas/ui/CardsResumo';
 import { GraficoTemas } from '../../../features/dashboard-turmas/ui/GraficoTemas';
 import { EmptyState } from '../../../features/dashboard-turmas/ui/EmptyState';
+import { TabelaDesempenhoIndividual } from '../../../features/dashboard-turmas/ui/TabelaDesempenhoIndividual';
 
 export const TurmaDetalhesPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -138,9 +139,7 @@ export const TurmaDetalhesPage = () => {
                     <Users size={20} className="text-gray-400" />
                     Desempenho Individual
                   </h3>
-                  <div className="flex h-48 items-center justify-center rounded-lg border-2 border-dashed border-gray-200 bg-gray-50 text-sm text-gray-400">
-                    [ Área reservada para a dupla: Tabela de Alunos (Visão Micro) ]
-                  </div>
+                  <TabelaDesempenhoIndividual turmaId={id!} />
                 </div>
               </div>
 


### PR DESCRIPTION
## Descrição

Implementação do frontend (Web) para o Dashboard de Desempenho da Turma, permitindo que professores visualizem métricas gerais, desempenho por tema e desempenho individual dos alunos diretamente na tela de detalhes da turma.

Foram criados:
- Página `TurmaDetalhesPage` com rota dedicada para o dashboard
- Cards de resumo com métricas gerais da turma (total de alunos, questões respondidas, taxa de acertos)
- Gráfico de desempenho por temas de anatomia
- Tabela de desempenho individual por aluno (questões respondidas e taxa de acerto)
- Estado vazio (empty state) para turmas sem dados
- Testes unitários cobrindo API, componentes e página

## Rastreabilidade

Issue(s) Relacionada(s):

Closes: #67

Commits relacionados:

- b9ce4ac feat: adiciona pagina de dashboard de turma
- b28cba7 test: adiciona teste para o dashboard de turma
- 2e5314a feat(dashboard-turma): adiciona card de desempenho individual dos alunos
- b34de8d test(dashboard-turma): adiciona testes para API e componente de desempenho individual

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Evidências (se aplicável)

<img width="1883" height="860" alt="image" src="https://github.com/user-attachments/assets/5f51b5bf-b7d8-4f14-a85b-0d775ff74c9b" />

<img width="1885" height="851" alt="image" src="https://github.com/user-attachments/assets/1a318b11-35cd-41cd-9497-1d7cedab062e" />

<img width="1888" height="850" alt="image" src="https://github.com/user-attachments/assets/e8d39025-753d-4735-bda9-4600d12e2a87" />


## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

