### PR TITLE
fix(perfil): corrige piscar do avatar e adiciona desequipar de cosmético

### DIFF
--- a/src/features/profile-cosmetics/ui/CosmeticsBootstrap.tsx
+++ b/src/features/profile-cosmetics/ui/CosmeticsBootstrap.tsx
@@ -48,7 +48,6 @@ export const CosmeticsBootstrap = () => {
 
     return () => {
       isMounted = false;
-      reset();
     };
   }, [reset, setCosmeticos, setError, setLoading, user?.id, user?.role]);
 

--- a/src/pages/aluno/perfil/personalizar/PersonalizarPerfilPage.tsx
+++ b/src/pages/aluno/perfil/personalizar/PersonalizarPerfilPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Check, Info, Save, ShoppingBag, X } from 'lucide-react';
+import { Ban, Check, Info, Save, ShoppingBag, X } from 'lucide-react';
 
 import { useAuth } from '../../../../app/providers/AuthProvider';
 import { useEquippedCosmeticsStore } from '../../../../features/profile-cosmetics';
@@ -111,6 +111,14 @@ export const PersonalizarPerfilPage = () => {
     });
   };
 
+  const removerCosmetico = (tipo: TipoItemLoja) => {
+    setStagedCosmetics((prev) => {
+      const novoStage = { ...prev };
+      delete novoStage[tipo];
+      return novoStage;
+    });
+  };
+
   const descartarAlteracoes = () => {
     setStagedCosmetics(cosmeticosEquipados);
   };
@@ -118,15 +126,22 @@ export const PersonalizarPerfilPage = () => {
   const salvarAlteracoes = async () => {
     setSalvando(true);
     try {
-      const promises = Object.values(stagedCosmetics).map(async (item) => {
-        if (!item) return;
+      const tipos: TipoItemLoja[] = [
+        'ICONE_PERFIL',
+        'MOLDURA',
+        'AVATAR',
+        'TITULO',
+        'PLANO_FUNDO',
+      ];
 
-        const itemOriginal = cosmeticosEquipados[item.tipo];
-        if (itemOriginal?.id !== item.id) {
+      const operacoes = tipos.map(async (tipo) => {
+        const original = cosmeticosEquipados[tipo];
+        const staged = stagedCosmetics[tipo];
+
+        // Equipar: há um item novo/diferente selecionado para o slot.
+        if (staged && staged.id !== original?.id) {
           try {
-            await httpClient.patch('/inventario/equipar', {
-              itemLojaId: item.id,
-            });
+            await httpClient.patch('/inventario/equipar', { itemLojaId: staged.id });
           } catch (error) {
             // Correção de lint: aserção de tipo em vez de 'any'
             const err = error as { response?: { status?: number } };
@@ -134,10 +149,16 @@ export const PersonalizarPerfilPage = () => {
               throw error;
             }
           }
+          return;
+        }
+
+        // Desequipar: o slot tinha um item equipado e foi removido (voltar ao padrão).
+        if (!staged && original) {
+          await httpClient.patch('/inventario/desequipar', { itemLojaId: original.id });
         }
       });
 
-      await Promise.all(promises);
+      await Promise.all(operacoes);
 
       setCosmeticosGlobais(stagedCosmetics);
       setModalSucesso(true);
@@ -237,6 +258,37 @@ export const PersonalizarPerfilPage = () => {
                 <div className="h-32 animate-pulse rounded-xl bg-gray-200" />
               ) : (
                 <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                  <button
+                    type="button"
+                    onClick={() => removerCosmetico(abaAtiva)}
+                    className={`relative flex cursor-pointer flex-col items-center gap-3 rounded-2xl border-2 bg-white p-4 transition-all ${
+                      !stagedCosmetics[abaAtiva]
+                        ? 'border-[#14b8a6] bg-teal-50/30 shadow-[0_0_0_4px_rgba(20,184,166,0.15)]'
+                        : 'border-gray-100 hover:border-[#14b8a6] hover:shadow-md'
+                    }`}
+                  >
+                    {!stagedCosmetics[abaAtiva] && (
+                      <div className="absolute right-3 top-3 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-[#14b8a6] text-white">
+                        <Check size={14} strokeWidth={3} />
+                      </div>
+                    )}
+                    <div className="flex h-24 w-full items-center justify-center">
+                      <div className="flex h-20 w-20 items-center justify-center rounded-2xl border-2 border-dashed border-gray-300 bg-gray-50 text-gray-400">
+                        <Ban size={28} />
+                      </div>
+                    </div>
+                    <div className="flex flex-col items-center">
+                      <span className="text-center text-sm font-black leading-tight text-[#00214d]">
+                        Nenhum (padrão)
+                      </span>
+                      {!stagedCosmetics[abaAtiva] && (
+                        <span className="mt-1 text-[10px] font-bold uppercase tracking-wider text-teal-600">
+                          Em uso
+                        </span>
+                      )}
+                    </div>
+                  </button>
+
                   {itensDaAbaAtual.map((registro) => {
                     const item = registro.item;
                     const estaEquipado = stagedCosmetics[abaAtiva]?.id === item.id;

--- a/test/unit/features/profile-cosmetics/ui/CosmeticsBootstrap.test.tsx
+++ b/test/unit/features/profile-cosmetics/ui/CosmeticsBootstrap.test.tsx
@@ -1,0 +1,87 @@
+import { render, waitFor } from '@testing-library/react';
+
+import { CosmeticsBootstrap } from '../../../../../src/features/profile-cosmetics/ui/CosmeticsBootstrap';
+import { buscarEquipados } from '../../../../../src/features/profile-cosmetics/cosmeticsService';
+import { useEquippedCosmeticsStore } from '../../../../../src/features/profile-cosmetics/model/useEquippedCosmeticsStore';
+import { useAuth } from '../../../../../src/app/providers/AuthProvider';
+
+jest.mock('../../../../../src/features/profile-cosmetics/cosmeticsService', () => ({
+  buscarEquipados: jest.fn(),
+}));
+
+jest.mock('../../../../../src/app/providers/AuthProvider', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('../../../../../src/features/profile-cosmetics/model/useEquippedCosmeticsStore', () => ({
+  useEquippedCosmeticsStore: jest.fn(),
+}));
+
+const mockedBuscar = jest.mocked(buscarEquipados);
+const mockedUseAuth = jest.mocked(useAuth);
+const mockedStore = jest.mocked(useEquippedCosmeticsStore);
+
+const setCosmeticos = jest.fn();
+const setLoading = jest.fn();
+const setError = jest.fn();
+const reset = jest.fn();
+
+type MockState = {
+  setCosmeticos: jest.Mock;
+  setLoading: jest.Mock;
+  setError: jest.Mock;
+  reset: jest.Mock;
+};
+
+const comoAluno = () =>
+  mockedUseAuth.mockReturnValue({
+    user: { id: 'user-1', role: 'STUDENT' },
+  } as unknown as ReturnType<typeof useAuth>);
+
+describe('CosmeticsBootstrap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedStore.mockImplementation((selector: unknown) => {
+      const state: MockState = { setCosmeticos, setLoading, setError, reset };
+      return (selector as (s: MockState) => unknown)(state);
+    });
+  });
+
+  it('carrega os cosméticos equipados do aluno ao montar', async () => {
+    comoAluno();
+    const slots = { ICONE_PERFIL: { id: 'item-1' } } as unknown as Awaited<
+      ReturnType<typeof buscarEquipados>
+    >;
+    mockedBuscar.mockResolvedValue(slots);
+
+    render(<CosmeticsBootstrap />);
+
+    await waitFor(() => expect(setCosmeticos).toHaveBeenCalledWith(slots));
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it('não reseta os cosméticos ao desmontar (evita o flash ao trocar de página)', async () => {
+    comoAluno();
+    mockedBuscar.mockResolvedValue({} as Awaited<ReturnType<typeof buscarEquipados>>);
+
+    const { unmount } = render(<CosmeticsBootstrap />);
+    await waitFor(() => expect(setCosmeticos).toHaveBeenCalled());
+    reset.mockClear();
+
+    unmount();
+
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it('reseta e não busca cosméticos quando o usuário não é aluno', () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: 'prof-1', role: 'PROFESSOR' },
+    } as unknown as ReturnType<typeof useAuth>);
+
+    render(<CosmeticsBootstrap />);
+
+    expect(reset).toHaveBeenCalled();
+    expect(mockedBuscar).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/pages/alunos/personalizar/PersonalizarPerfilPage.test.tsx
+++ b/test/unit/pages/alunos/personalizar/PersonalizarPerfilPage.test.tsx
@@ -185,6 +185,31 @@ describe('PersonalizarPerfilPage', () => {
     expect(mockSetCosmeticosGlobais).toHaveBeenCalled();
   });
 
+  it('deve desequipar (PATCH /inventario/desequipar) ao escolher "Nenhum (padrão)" e salvar', async () => {
+    const mockResponse: Partial<AxiosResponse> = {
+      data: {
+        dados: [ITEM_CORUJA, ITEM_CEREBRO],
+      },
+    };
+    mockedHttpClient.get.mockResolvedValueOnce(mockResponse as AxiosResponse);
+    mockedHttpClient.patch.mockResolvedValueOnce({ status: 200 } as AxiosResponse);
+
+    renderWithProviders(<PersonalizarPerfilPage />);
+    await waitFor(() => expect(screen.getByText('Coruja')).toBeInTheDocument());
+
+    // Remove o item equipado escolhendo "Nenhum (padrão)".
+    fireEvent.click(screen.getByText('Nenhum (padrão)'));
+
+    const saveBtn = await screen.findByRole('button', { name: /Salvar alterações/i });
+    fireEvent.click(saveBtn);
+
+    expect(await screen.findByText('Sucesso!')).toBeInTheDocument();
+    expect(mockedHttpClient.patch).toHaveBeenCalledWith('/inventario/desequipar', {
+      itemLojaId: 'item-1',
+    });
+    expect(mockSetCosmeticosGlobais).toHaveBeenCalled();
+  });
+
   it('deve navegar para a loja ao clicar em Ver mais na Loja', async () => {
     const mockResponse: Partial<AxiosResponse> = { data: { dados: [] } };
     mockedHttpClient.get.mockResolvedValueOnce(mockResponse as AxiosResponse);


### PR DESCRIPTION
## O que
Corrige dois problemas da personalização de perfil.

## 1) Avatar pisca ao navegar (ex.: clicar em "Início")
"Início" leva a `/home` (fora do `AuthenticatedLayout`); o `CosmeticsBootstrap` desmontava e **resetava** os cosméticos, e ao voltar para `/aluno/home` re-buscava — deixando o avatar em branco no meio (piscada).
- **Fix:** remove o `reset()` do cleanup do `CosmeticsBootstrap` (o reset por logout/troca de papel é mantido). O store mantém os cosméticos no ida-e-volta.

## 2) Não dava para desequipar (voltar ao padrão)
- Adiciona a opção **"Nenhum (padrão)"** em cada categoria da personalização.
- O salvamento agora trata **equipar e desequipar** (chama `PATCH /inventario/desequipar` para slots removidos).

## Testes
- Novo teste do `CosmeticsBootstrap` (carrega no mount; **não reseta no unmount**; reseta para não-aluno).
- Teste de desequipar na `PersonalizarPerfilPage`.
- Suíte completa verde (717 testes), build e lint ok.

> Depende do endpoint `PATCH /inventario/desequipar` (PR do Quiz-Service).