### PR TITLE
fix(questoes): envia e le palavras-chave das questoes

### DIFF
--- a/src/features/manage-questions/model/questionService.ts
+++ b/src/features/manage-questions/model/questionService.ts
@@ -49,6 +49,7 @@ type BackendQuestion = Partial<Omit<Question, 'tema' | 'alternativas'>> & {
   tema?: string | Partial<QuestionTopic>;
   topic?: string;
   tags?: string[] | string;
+  palavrasChave?: string[] | string;
   type?: string;
   difficulty?: string;
   origem?: string;
@@ -198,7 +199,7 @@ const normalizeAlternatives = (
 const normalizeQuestion = (question: BackendQuestion): ProfessorQuestion => ({
   id: question.id,
   topic: normalizeTopic(question.tema, question.topic),
-  tags: normalizeTags(question.tags),
+  tags: normalizeTags(question.palavrasChave ?? question.tags),
   type: mapTypeFromApi(question.type ?? question.tipo),
   difficulty: mapDifficultyFromApi(question.difficulty ?? question.dificuldade),
   origemQuestao: question.origemQuestao ?? 'ELABORADA_POR_PROFESSOR',
@@ -233,6 +234,7 @@ const buildFormData = (values: QuestionFormValues): FormData => {
   formData.append('origemQuestao', values.origemQuestao || '');
   formData.append('taxonomiaBloom', values.taxonomiaBloom || '');
   formData.append('regiaoAnatomica', (values.regiaoAnatomica || '').trim());
+  formData.append('palavrasChave', (values.tags || '').trim());
 
   const correctAlternative = values.alternatives.find((alt) => alt.isCorrect);
   if (correctAlternative) {

--- a/test/unit/features/manage-questions/model/questionService.test.ts
+++ b/test/unit/features/manage-questions/model/questionService.test.ts
@@ -260,6 +260,22 @@ describe('questionService', () => {
       expect(formData.get('origemQuestao')).toBe('LIVRO');
       expect(formData.get('taxonomiaBloom')).toBe('APLICAR');
       expect(formData.get('regiaoAnatomica')).toBe('Abdome'); // trim aplicado
+      expect(formData.get('palavrasChave')).toBe('aorta, mediastino');
+    });
+
+    it('prioriza palavrasChave do backend sobre tags ao normalizar', async () => {
+      const { listProfessorQuestions } = await loadService(false);
+      getMock.mockResolvedValueOnce({
+        data: {
+          dados: [
+            { id: 'q1', palavrasChave: ['coração', 'aorta'], tags: 'ignorado', alternativas: null },
+          ],
+        },
+      });
+
+      const res = await listProfessorQuestions();
+
+      expect(res[0].tags).toEqual(['coração', 'aorta']);
     });
 
     it('normaliza os campos de classificacao retornados pelo backend', async () => {


### PR DESCRIPTION
## Descrição

Corrige o bug em que as **palavras-chave das questões não eram salvas**. No front, o formulário possuía o campo de palavras-chave, mas ele **não era enviado** no payload de criação/edição (e a leitura também não considerava o campo do backend).

Mudanças na Web:
- `buildFormData` passa a enviar `palavrasChave` ao criar/editar questões.
- `normalizeQuestion` passa a ler `palavrasChave` retornado pelo backend.

Depende do PR do Quiz-Service (que adiciona a persistência) para o fluxo funcionar de ponta a ponta.

## Rastreabilidade

Issue(s) Relacionada(s):

Closes:
Relates to: fga-eps-mds/2026-1-AnatoQuizUp-Doc#42


Commits relacionados:

- e397d62 — fix(questoes): envia e le palavras-chave no formulario de questoes
- bf68bee — test(questoes): cobre envio e leitura das palavras-chave


## Tipo de Mudança

- [ ] Feature (nova funcionalidade)
- [x] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [ ] Testes


## Evidências (se aplicável)

- Validado em conjunto com o backend via fluxo real (criar/editar questão com palavras-chave → persistem e voltam na listagem/edição).
- `jest --coverage`: 745 testes passando; gate de cobertura global de 85% atendido.
- (prints/GIFs da tela de questões podem ser adicionados posteriormente)


## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes


## Observações

Par da correção do Quiz-Service. O BFF não precisou de mudança (o proxy de `/questoes` já repassa o campo novo).
